### PR TITLE
fix: factor in AP and number of attacks in damage application

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,9 @@
+import { OUTERHEAVEN } from "./module/config.mjs";
+import * as weaponAttack from "./module/weapon-attack.mjs";
+
+export {};
+
+declare global {
+    type DamageType = keyof typeof OUTERHEAVEN.damageTypes;
+    interface DamageInstance extends weaponAttack.DamageInstance {}
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -9,5 +9,5 @@
         "checkJs": false
     },
     "exclude": ["node_modules", "dist"],
-    "include": ["**/*.js", "**/*.mjs", "**/*.d.ts", "client", "common"]
+    "include": ["**/*.js", "**/*.mjs", "**/*.d.ts", "client", "common", "global.d.ts"]
 }


### PR DESCRIPTION
This should fix the generic apply damage button so that it correctly factors in the number of attacks and the attack's armor penetration (similarly to the calculation done by the attack for its set results), too.