### PR TITLE
feat: enable opening configured compendiums from actor sheets

### DIFF
--- a/module/applications/item-compendiums.mjs
+++ b/module/applications/item-compendiums.mjs
@@ -1,0 +1,86 @@
+import { SYSTEM_ID } from "../const.mjs";
+
+/**
+ * A form application for configuring which compendiums to open when importing items of a specific type to an actor sheet.
+ */
+export class ItemCompendiumConfig extends FormApplication {
+    constructor(object, options) {
+        super(object || game.settings.get(SYSTEM_ID, "itemCompendiums"), options);
+    }
+
+    /** @override */
+    static get defaultOptions() {
+        const options = super.defaultOptions;
+        return {
+            ...options,
+            id: `${SYSTEM_ID}-item-compendiums`,
+            title: game.i18n.localize("OH.Settings.ItemCompendiums.Name"),
+            classes: [...options.classes, SYSTEM_ID, "item-compendiums"],
+            template: `systems/${SYSTEM_ID}/templates/applications/item-compendiums.hbs`,
+            width: 600,
+            height: "auto",
+            closeOnSubmit: true,
+        };
+    }
+
+    /** @override */
+    async getData() {
+        const context = await super.getData();
+
+        const itemTypes = game.system.template.Item.types;
+        const packs = Object.fromEntries(game.packs.map((pack) => [pack.metadata.id, pack.metadata.label]));
+
+        context.compendiums = {};
+        for (const type of itemTypes) {
+            context.compendiums[type] = {
+                label: game.i18n.format("OH.Settings.ItemCompendiums.TypeLabel", {
+                    type: game.i18n.localize(CONFIG.Item.typeLabels[type]),
+                }),
+                type: type,
+                current: this.object[type],
+                choices: foundry.utils.deepClone(packs),
+            };
+        }
+
+        return context;
+    }
+
+    /** @override */
+    _updateObject(_event, formData) {
+        return game.settings.set(SYSTEM_ID, "itemCompendiums", formData);
+    }
+
+    /** @override */
+    activateListeners(html) {
+        super.activateListeners(html);
+        html.find("[data-action='reset']").on("click", async (event) => {
+            event.preventDefault();
+            // Only reset object of the current config app, require saving to persist
+            this.object = new ItemCompendiumSettings();
+            this.render();
+        });
+    }
+}
+
+/**
+ * Settings for which compendium to open when importing items of a specific type to an actor sheet.
+ */
+export class ItemCompendiumSettings extends foundry.abstract.DataModel {
+    /** @override */
+    static defineSchema() {
+        const fields = foundry.data.fields;
+        // Use game.data to enable verification of fields even when Foundry is not ready yet
+        const choices = Array.from(
+            new Set([...game.packs, ...game.data.packs].map((pack) => pack.id ?? pack.metadata.id)),
+        );
+        return game.system.template.Item.types.reduce((acc, type) => {
+            acc[type] = new fields.StringField({
+                initial: "",
+                nullable: false,
+                blank: true,
+                choices,
+            });
+            return acc;
+        }, {});
+    }
+}

--- a/module/const.mjs
+++ b/module/const.mjs
@@ -1,0 +1,4 @@
+/**
+ * The ID of the system/package.
+ */
+export const SYSTEM_ID = "outerheaven";

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -1,3 +1,6 @@
+import { ItemCompendiumConfig, ItemCompendiumSettings } from "./applications/item-compendiums.mjs";
+import { SYSTEM_ID } from "./const.mjs";
+
 /**
  * Register the system's settings.
  *
@@ -5,7 +8,7 @@
  */
 export function registerSettings() {
     // Damage dice explosion
-    game.settings.register("outerheaven", "criticals", {
+    game.settings.register(SYSTEM_ID, "criticals", {
         name: "OH.Settings.Criticals.Name",
         hint: "OH.Settings.Criticals.Hint",
         scope: "world",
@@ -17,5 +20,21 @@ export function registerSettings() {
             limited: "OH.Settings.Criticals.Limited",
             none: "OH.Settings.Criticals.None",
         },
+    });
+
+    // Compendium buttons
+    game.settings.register(SYSTEM_ID, "itemCompendiums", {
+        type: ItemCompendiumSettings,
+        scope: "world",
+        config: false,
+        default: new ItemCompendiumSettings().toObject(),
+    });
+    game.settings.registerMenu(SYSTEM_ID, "itemCompendiums", {
+        name: "OH.Settings.ItemCompendiums.Name",
+        label: "OH.Settings.ItemCompendiums.Label",
+        hint: "OH.Settings.ItemCompendiums.Hint",
+        icon: "fas fa-book",
+        type: ItemCompendiumConfig,
+        restricted: true,
     });
 }

--- a/module/sheets/unit.mjs
+++ b/module/sheets/unit.mjs
@@ -1,3 +1,4 @@
+import { SYSTEM_ID } from "../const.mjs";
 import { OHArmor } from "../data/armor.mjs";
 import { onManageActiveEffect, prepareActiveEffectCategories } from "../effects.mjs";
 
@@ -99,6 +100,7 @@ export class OHUnitSheet extends ActorSheet {
 
         // Add Inventory Item
         html.find(".item-create").click(this._onItemCreate.bind(this));
+        html.find(".item-import").click(this._onItemImport.bind(this));
 
         // Delete Inventory Item
         html.find(".item-delete").click((ev) => {
@@ -147,6 +149,22 @@ export class OHUnitSheet extends ActorSheet {
 
         // Finally, create the item!
         return await Item.create(itemData, { parent: this.actor });
+    }
+
+    /**
+     * Handle opening compendium applications for a certain item type.
+     *
+     * @param {Event} event - The originating click event.
+     * @private
+     */
+    _onItemImport(event) {
+        event.preventDefault();
+        const createButton = event.currentTarget.previousElementSibling;
+        const type = createButton.dataset.type;
+
+        const itemCompendiums = game.settings.get(SYSTEM_ID, "itemCompendiums");
+        if (!itemCompendiums[type]) return;
+        game.packs.get(itemCompendiums[type]).render(true);
     }
 
     async _onInlineEdit(event) {

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -20,6 +20,12 @@
                 "Unlimited": "Unlimited explosion (x)",
                 "Limited": "Explosion limited to 1 (xo)",
                 "None": "No explosion"
+            },
+            "ItemCompendiums": {
+                "Name": "Item Compendiums",
+                "Hint": "Compendiums opened when importing items in an actor sheet",
+                "Label": "Open Item Compendium Configuration",
+                "TypeLabel": "{type} Compendium"
             }
         },
 

--- a/static/templates/applications/item-compendiums.hbs
+++ b/static/templates/applications/item-compendiums.hbs
@@ -1,0 +1,14 @@
+<form autocomplete="off">
+  {{#each compendiums as |compendium id|}}
+    <div class="form-group">
+      <label>{{compendium.label}}</label>
+      <select name="{{compendium.type}}">
+        {{selectOptions compendium.choices selected=compendium.current blank=""}}
+      </select>
+    </div>
+  {{/each}}
+  <div class="form-group">
+    <button type="submit"><i class="fas fa-save"></i>{{localize "SETTINGS.Save"}}</button>
+    <button type="button" data-action="reset"><i class="fas fa-undo"></i>{{localize "SETTINGS.Reset"}}</button>
+  </div>
+</form>


### PR DESCRIPTION
This introduces a new setting menu allowing GMs to set which compendium should be opened when the compendium button in an actor sheet's category header is clicked.
The setting is validated to ensure each field is an actual compendium. Available choices include all compendiums.

![image](https://github.com/LDMonay/oh-foundry/assets/589855/a0fc6528-e259-43cb-ba8a-b50b5e0fadd2)
