### PR TITLE
feat: use full editors for item descriptions

### DIFF
--- a/module/data/templates.mjs
+++ b/module/data/templates.mjs
@@ -4,7 +4,7 @@ const fields = foundry.data.fields;
  * Basic description data common to items
  */
 export const DescriptionTemplate = () => ({
-    description: new fields.StringField({ textSearch: true, blank: true, initial: "" }),
+    description: new fields.HTMLField({ textSearch: true, blank: true, initial: "" }),
     tags: new fields.StringField({ textSearch: true, blank: true, initial: "" }),
 });
 

--- a/module/sheets/item.mjs
+++ b/module/sheets/item.mjs
@@ -43,20 +43,29 @@ export class OHItemSheet extends ItemSheet {
     }
 
     /** @override */
-    getData() {
+    async getData() {
         // Retrieve base data structure.
         const context = super.getData();
+        const item = (context.item = this.item);
+        const rollData = item.getRollData();
 
         context.config = CONFIG.OUTERHEAVEN;
 
-        if (this.type === "armor") {
+        if (item.type === "armor") {
             context.armorTypes = { ...CONFIG.OUTERHEAVEN.damageTypes };
             context.armorTypes.true = "All";
         }
 
         // Add the actor's data to context.data for easier access, as well as flags.
-        context.system = this.item.system;
-        context.flags = this.item.flags;
+        context.system = item.system;
+        context.flags = item.flags;
+
+        context.description = await TextEditor.enrichHTML(item.system.description, {
+            rollData,
+            secrets: item.isOwner,
+            async: true,
+            relativeTo: item,
+        });
 
         return context;
     }

--- a/static/template.json
+++ b/static/template.json
@@ -3,6 +3,7 @@
         "types": ["unit"]
     },
     "Item": {
-        "types": ["weapon", "equipment", "ability", "skill", "armor"]
+        "types": ["weapon", "equipment", "ability", "skill", "armor"],
+        "htmlFields": ["description"]
     }
 }

--- a/static/templates/sheets/ability-sheet.hbs
+++ b/static/templates/sheets/ability-sheet.hbs
@@ -21,7 +21,7 @@
             </table>
         </div>
         <div class="itemSection">
-            <textarea name="system.description">{{system.description}}</textarea>
+            {{editor description target="system.description" button=true engine="prosemirror" owner=owner editable=editable}}
         </div>
         <div>
             <p class="floatLeft">

--- a/static/templates/sheets/armor-sheet.hbs
+++ b/static/templates/sheets/armor-sheet.hbs
@@ -39,7 +39,7 @@
         </div>
         <hr />
         <div class="itemSection">
-            <textarea name="system.description">{{system.description}}</textarea>
+            {{editor description target="system.description" button=true engine="prosemirror" owner=owner editable=editable}}
         </div>
         <div>
             <p class="floatLeft">

--- a/static/templates/sheets/equipment-sheet.hbs
+++ b/static/templates/sheets/equipment-sheet.hbs
@@ -21,7 +21,7 @@
             </table>
         </div>
         <div class="itemSection">
-            <textarea name="system.description">{{system.description}}</textarea>
+            {{editor description target="system.description" button=true engine="prosemirror" owner=owner editable=editable}}
         </div>
         <div>
             <p class="floatLeft">

--- a/static/templates/sheets/skill-sheet.hbs
+++ b/static/templates/sheets/skill-sheet.hbs
@@ -10,7 +10,7 @@
         </div>
         <hr />
         <div class="itemSection">
-            <textarea name="system.description">{{system.description}}</textarea>
+            {{editor description target="system.description" button=true engine="prosemirror" owner=owner editable=editable}}
         </div>
         <div>
             <p class="floatLeft">

--- a/static/templates/sheets/weapon-sheet.hbs
+++ b/static/templates/sheets/weapon-sheet.hbs
@@ -20,7 +20,7 @@
             {{/if}}
         </div>
         <div class="itemSection">
-            <textarea name="system.description">{{system.description}}</textarea>
+            {{editor description target="system.description" button=true engine="prosemirror" owner=owner editable=editable}}
         </div>
         <div>
             <p class="floatLeft">


### PR DESCRIPTION
This introduces full HTML descriptions for items based on the ProseMirror editor.
Style changes to fine-tune editor sizes are not included, as that is probably better done after the expected AE changes which in turn will affect the overall sheet layout.