### PR TITLE
Fix descriptions

### DIFF
--- a/less/character-sheet.less
+++ b/less/character-sheet.less
@@ -57,12 +57,12 @@
 
 .outerheaven.character-sheet {
     .items {
-        .items-list {
+        .item-list {
             padding: 0;
             margin: 0.2em 0;
         }
 
-        .items-list-header {
+        .item-list-header {
             font-weight: bold;
             padding: 0.25em;
             background: rgba(0, 0, 0, 0.1);
@@ -74,7 +74,7 @@
         }
 
         // Using the same dimensions for header and item to keep them uniform
-        .items-list-header,
+        .item-list-header,
         .item {
             text-align: center;
             padding: 0.2em 0;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -27,6 +27,11 @@ export class OHItem extends Item {
 
         // Retrieve roll data.
         const rollData = this.getRollData();
+        rollData.description = await TextEditor.enrichHTML(this.system.description, {
+            rollData,
+            relativeTo: this.actor,
+            async: true,
+        });
         const rollContent = await renderTemplate(this.constructor.displayTemplate[this.type], rollData);
 
         ChatMessage.create({

--- a/static/templates/chat/defense-display.hbs
+++ b/static/templates/chat/defense-display.hbs
@@ -5,8 +5,8 @@
     <div><i>{{item.system.benefitsDescription}}</i></div>
     <hr />
     {{/if}}
-    {{#if item.system.description}}
-    <div>{{item.system.description}}</div>
+    {{#if description}}
+    <div>{{{description}}}</div>
     <hr />
     {{/if}}
     <table class="center">

--- a/static/templates/chat/item-display.hbs
+++ b/static/templates/chat/item-display.hbs
@@ -1,7 +1,7 @@
 <div class="chatMessage">
     <div class="fitToContent">
         <div class="floatLeft"><img src="{{item.img}}" data-edit="img" title="{{item.name}}" height="32" width="32"/></div>&nbsp&nbsp<h2 class="floatRight">{{item.name}}</h2> </div>
-    <div>{{item.system.description}}</div>
+    <div>{{{description}}}</div>
     <hr />
     <table class="center">
         <tr>

--- a/static/templates/sheets/parts/unit-weapons.hbs
+++ b/static/templates/sheets/parts/unit-weapons.hbs
@@ -1,6 +1,6 @@
 <section class="items weapons flexcol">
   {{!-- Header row, mirroring the contents of an item list element --}}
-  <header class="items-list-header flexrow">
+  <header class="item-list-header flexrow">
     <div class="name">{{localize inventory.weapons.label}}</div>
     <div class="use"></div>
     <div class="actions">ATF</div>
@@ -13,7 +13,7 @@
     </div>
   </header>
 
-  <ol class="items-list">
+  <ol class="item-list">
     {{#each inventory.weapons.items as |item id|}}
       {{!-- Each individual item's list element --}}
       <li class="item flexrow" data-item-id="{{item._id}}">


### PR DESCRIPTION
Fixes two issues:
1. Item descriptions in chat cards were not properly enriched, but still treated as raw text.
2. Weapons in unit sheets were not draggable, as their list's class had a typo, preventing the default DragDrop selector from applying.