### PR TITLE
feat: active effects and more

### DIFF
--- a/less/character-sheet.less
+++ b/less/character-sheet.less
@@ -56,45 +56,21 @@
 }
 
 .outerheaven.character-sheet {
+    .form-item {
+        width: 100%;
+        min-height: 36px;
+        label {
+            flex: 0 0 4em;
+        }
+    }
+
+    .stance {
+        align-self: normal;
+    }
+
     .items {
-        .item-list {
-            padding: 0;
-            margin: 0.2em 0;
-        }
-
-        .item-list-header {
-            font-weight: bold;
-            padding: 0.25em;
-            background: rgba(0, 0, 0, 0.1);
-            border: 1px groove rgba(0, 0, 0, 0.1);
-
-            .name {
-                margin-left: 5px;
-            }
-        }
-
-        // Using the same dimensions for header and item to keep them uniform
         .item-list-header,
         .item {
-            text-align: center;
-            padding: 0.2em 0;
-
-            &:nth-child(even) {
-                background: rgba(0, 0, 0, 0.05);
-            }
-
-            // Vertically center contained elements/text
-            > * {
-                align-self: center;
-            }
-
-            .name {
-                text-align: left;
-                flex: 1.1 0 4em;
-                > span {
-                    align-self: center;
-                }
-            }
             .use {
                 flex: 0 0 24px;
             }
@@ -130,20 +106,6 @@
                     flex: 0.2 1 max-content;
                     align-self: center;
                 }
-            }
-
-            .icon {
-                max-width: 24px;
-                max-height: 24px;
-                margin-right: 5px;
-            }
-        }
-
-        .item-controls {
-            flex: 0 0 3em;
-            margin-left: 5px;
-            > a {
-                margin-left: 5px;
             }
         }
     }

--- a/less/character-sheet.less
+++ b/less/character-sheet.less
@@ -107,6 +107,14 @@
                     align-self: center;
                 }
             }
+
+            .armor {
+                flex: 2 0 4em;
+            }
+
+            .benefits {
+                flex: 0.8 0 2em;
+            }
         }
     }
 }

--- a/less/common.less
+++ b/less/common.less
@@ -1,0 +1,60 @@
+.outerheaven {
+    .item-list,
+    .effect-list {
+        padding: 0;
+        margin: 0.2em 0;
+    }
+
+    // Specific styling for the header row
+    .item-list-header,
+    .effect-list-header {
+        font-weight: bold;
+        padding: 0.25em;
+        background: rgba(0, 0, 0, 0.1);
+        border: 1px groove rgba(0, 0, 0, 0.1);
+
+        .name {
+            padding-left: 5px;
+        }
+    }
+
+    // Common styling for the header and item rows
+    .item-list .item,
+    .item-list-header,
+    .effect,
+    .effect-list-header {
+        text-align: center;
+        padding: 0.2em 0;
+
+        &:nth-child(even) {
+            background: rgba(0, 0, 0, 0.05);
+        }
+
+        // Vertically center contained elements/text
+        > * {
+            align-self: center;
+        }
+
+        .name {
+            text-align: left;
+            flex: 1.1 0 4em;
+            > span {
+                align-self: center;
+            }
+        }
+
+        .icon {
+            max-width: 24px;
+            max-height: 24px;
+            margin-right: 5px;
+        }
+
+        .item-controls {
+            flex: 0 0 3em;
+            margin-left: 5px;
+            > a {
+                margin-left: 5px;
+            }
+        }
+    }
+}

--- a/less/item-sheet.less
+++ b/less/item-sheet.less
@@ -1,4 +1,4 @@
-.itemSheet {
+.item-sheet {
     .vCenter {
         vertical-align: middle;
     }
@@ -41,5 +41,19 @@
     }
     textarea {
         min-height: 80px;
+    }
+}
+
+.outerheaven.item-sheet {
+    .benefits {
+        flex: 1.3 0 4em;
+        textarea {
+            height: calc(100% - 1.5em);
+            resize: none;
+        }
+    }
+
+    .armor-bonuses {
+        margin-left: 1em;
     }
 }

--- a/less/outerheaven.less
+++ b/less/outerheaven.less
@@ -1,3 +1,4 @@
 @import "./character-sheet.less";
 @import "./item-sheet.less";
 @import "./chat-messages.less";
+@import "./common.less";

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -39,4 +39,9 @@ OUTERHEAVEN.armorTypes = {
     all: "OH.DamageTypes.All",
 };
 
+OUTERHEAVEN.effectTypes = {
+    stance: "OH.EffectTypes.Stance",
+    template: "OH.EffectTypes.Template",
+};
+
 OUTERHEAVEN.ACTIONS = {};

--- a/module/data/_module.mjs
+++ b/module/data/_module.mjs
@@ -5,6 +5,10 @@ export * from "./armor.mjs";
 export * from "./equipment.mjs";
 export * from "./skill.mjs";
 export * from "./weapon.mjs";
+export * from "./form.mjs";
 
 // Actor models by type
 export * from "./unit.mjs";
+
+// Fields
+export * as fields from "./fields/_module.mjs";

--- a/module/data/active-effect.mjs
+++ b/module/data/active-effect.mjs
@@ -1,0 +1,8 @@
+export class ActiveEffectModel extends foundry.abstract.DataModel {
+    static defineSchema() {
+        const fields = foundry.data.fields;
+        return {
+            type: new fields.StringField({ nullable: true, blank: true, choices: outerheaven.config.effectTypes }),
+        };
+    }
+}

--- a/module/data/active-effect.mjs
+++ b/module/data/active-effect.mjs
@@ -1,7 +1,13 @@
+/**
+ * The `DataModel` used for the system's ActiveEffect data.
+ * In lieu of a dedicated `system` space, this is stored in `flags.outerheaven`, but made available as `system`.
+ */
 export class ActiveEffectModel extends foundry.abstract.DataModel {
+    /** @override */
     static defineSchema() {
         const fields = foundry.data.fields;
         return {
+            /** The effect type demanding special treatment by the system; can be blank to use the default behavior. */
             type: new fields.StringField({ nullable: true, blank: true, choices: outerheaven.config.effectTypes }),
         };
     }

--- a/module/data/fields/_module.mjs
+++ b/module/data/fields/_module.mjs
@@ -1,0 +1,1 @@
+export * from "./local-document.mjs";

--- a/module/data/fields/local-document.mjs
+++ b/module/data/fields/local-document.mjs
@@ -1,0 +1,45 @@
+/**
+ * A field which stores a reference to an embedded document, similar to {@link foundry.data.fields.ForeignDocumentField}.
+ */
+export class LocalDocumentField extends foundry.data.fields.DocumentIdField {
+    constructor(model, options = {}) {
+        if (!foundry.utils.isSubclass(model, foundry.abstract.DataModel)) {
+            throw new Error("A LocalDocumentField must specify a DataModel subclass as its type");
+        }
+        super(options);
+        /**
+         * A reference to the model class which is stored in this field.
+         * @type {typeof Document}
+         */
+        this.model = model;
+    }
+
+    /** @override */
+    static get _defaults() {
+        return foundry.utils.mergeObject(super._defaults, {
+            nullable: true,
+            readonly: false,
+            idOnly: false,
+        });
+    }
+
+    /** @override */
+    _cast(value) {
+        if (typeof value === "string") return value;
+        // Return the document's `id` for storage in the database.
+        if (value instanceof this.model) return value._id;
+        throw new Error(`The value provided to a LocalDocumentField must be a ${this.model.name} instance.`);
+    }
+
+    /** @override */
+    initialize(value, model, options = {}) {
+        if (this.idOnly) return value;
+        const collection = model.parent?.[this.model.metadata.collection];
+        return () => collection?.get(value) ?? null;
+    }
+
+    /** @override */
+    toObject(value) {
+        return value?._id ?? value;
+    }
+}

--- a/module/data/fields/local-effect.mjs
+++ b/module/data/fields/local-effect.mjs
@@ -1,0 +1,38 @@
+import { LocalDocumentField } from "./local-document.mjs";
+
+/**
+ * A field which stores a reference to an ActiveEffect document embedded in an Item embedded in an Actor.
+ * The value of this field is a relative UUID string in the form of ".Item.abc123.ActiveEffect.def456".
+ */
+export class LocalEffectField extends LocalDocumentField {
+    constructor(options = {}) {
+        // Replace `model` parameter with a hardcoded reference to the ActiveEffect model.
+        super(foundry.documents.BaseActiveEffect, options);
+    }
+
+    /** @override */
+    initialize(value, model, options = {}) {
+        if (this.idOnly) return value;
+        // Retrieve the effect using its relative UUID, and check if it is of the correct type.
+        return () => {
+            const effect = fromUuidSync(value, { relative: model.parent }) ?? null;
+            if (options.type && effect?.system?.type !== options.type) return null;
+            return effect;
+        };
+    }
+
+    /** @override */
+    _cast(value) {
+        if (typeof value === "string") return value;
+        // Do not use the normal `id` field, but generate an actor-relative UUID instead.
+        if (value instanceof this.model) return value.getRelativeUUID(null, { toActor: true });
+        throw new Error(`The value provided to a LocalEffectField must be a ${this.model.name} instance.`);
+    }
+
+    /** @override */
+    _validateType(value) {
+        // The value must adhere to a schema of ".Item.abc123.ActiveEffect.def456".
+        const result = /.Item.[a-zA-Z0-9]{16}.ActiveEffect.[a-zA-Z0-9]{16}/.test(value);
+        if (!result) throw new Error(`The value provided to a LocalEffectField must be a UUID string.`);
+    }
+}

--- a/module/data/form.mjs
+++ b/module/data/form.mjs
@@ -1,0 +1,7 @@
+export class OHForm extends foundry.abstract.TypeDataModel {
+    /** @override */
+    static defineSchema() {
+        const fields = foundry.data.fields;
+        return {};
+    }
+}

--- a/module/documents/_module.mjs
+++ b/module/documents/_module.mjs
@@ -1,3 +1,4 @@
 export * from "./actor.mjs";
 export * from "./item.mjs";
 export * from "./chat-message.mjs";
+export * from "./active-effect.mjs";

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -18,7 +18,7 @@ export class OHActiveEffect extends ActiveEffect {
     get isSuppressed() {
         // Only the currently chosen stance is active and applied
         if (this.system.type === "stance") {
-            return this.actor.system.stance !== this;
+            return this.actor?.system.stance !== this;
         }
         return false;
     }

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -1,0 +1,70 @@
+import { ActiveEffectModel } from "../data/active-effect.mjs";
+
+export class OHActiveEffect extends ActiveEffect {
+    /**
+     * The actor this ActiveEffect is eventually embedded in.
+     *
+     * @type {Actor}
+     */
+    get actor() {
+        return this.parent?.actor;
+    }
+
+    /**
+     * Whether this ActiveEffect is suppressed due to system-specific logic, or should affect the actor.
+     *
+     * @type {boolean}
+     */
+    get isSuppressed() {
+        // Only the currently chosen stance is active and applied
+        if (this.system.type === "stance") {
+            return this.actor.system.stance !== this;
+        }
+        return false;
+    }
+
+    /** @override */
+    _initialize(options) {
+        // TODO: Properly sort order in data preparation
+        this.system.updateSource(this._source?.flags?.outerheaven ?? {});
+        super._initialize(options);
+    }
+
+    /** @override */
+    _configure(options) {
+        super._configure(options);
+        this.system = new ActiveEffectModel(this._source.flags?.outerheaven ?? {}, { parent: this });
+    }
+
+    /** @override */
+    prepareDerivedData() {
+        // Never transfer "template" type effects that are meant to be applied to _other_ actors
+        if (this.system.type === "template") this.transfer = false;
+    }
+
+    /**
+     * Enhance the default implementation with the option to get a relative UUID
+     * for an ActiveEffect embedded in an Item embedded in an Actor.
+     *
+     * @override
+     * @returns {string} The relative UUID for this ActiveEffect
+     */
+    getRelativeUUID(doc, { toActor = false } = {}) {
+        if (toActor) {
+            if (this.actor)
+                return `.${this.parent.constructor.documentName}.${this.parent.id}.${this.constructor.documentName}.${this.id}`;
+        }
+        return super.getRelativeUUID(doc);
+    }
+}
+
+/**
+ * @param {Application} app
+ * @param {JQuery} html
+ * @param {object} data
+ */
+export function onRenderActiveEffectConfig(app, html, data) {
+    const renderData = { ...data, system: app.object.system, config: outerheaven.config };
+    const newHtml = Handlebars.partials["oh.ae-config"](renderData);
+    html.find(".tab[data-tab='details']").append(newHtml);
+}

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1,36 +1,13 @@
-import { OUTERHEAVEN } from "../config.mjs";
 import { OHArmor } from "../data/armor.mjs";
 
 export class OHActor extends Actor {
-    /** @override */
-    prepareDerivedData() {
-        const actorData = this;
-        const systemData = actorData.system;
-
-        // Armor Total
-        systemData.armor = this.itemTypes.armor.reduce(
-            (acc, item) => {
-                for (const armorBonus of item.system.armorBonuses) {
-                    if (armorBonus.armorType === "all") {
-                        for (const armorType of Object.keys(OUTERHEAVEN.armorTypes)) {
-                            acc[armorType] += armorBonus.value;
-                        }
-                    } else acc[armorBonus.armorType] += armorBonus.value;
-                }
-                return acc;
-            },
-            Object.fromEntries(Object.keys(OUTERHEAVEN.armorTypes).map((key) => [key, 0])),
-        );
-
-        // Points
-        const baseUnitPoints = systemData.baseUnitPointsIgnore ? 0 : systemData.baseUnitPoints;
-        const pointsTotal = this.items.reduce((acc, item) => {
-            if (!item.system.ignoreCost) {
-                acc += item.system.pointCost;
-            }
-            return acc;
-        }, baseUnitPoints);
-        systemData.totalPoints = pointsTotal;
+    /**
+     * The actor's `form` type item, if any.
+     *
+     * @type {OHItem | null}
+     */
+    get form() {
+        return this.items.find((item) => item.type === "form") ?? null;
     }
 
     /**

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -7,6 +7,14 @@ export class OHItem extends Item {
         weapon: "systems/outerheaven/templates/chat/weapon-display.hbs",
     };
 
+    /** @override */
+    async _preCreate(data, options, user) {
+        await super._preCreate(data, options, user);
+
+        // Prevent the creation of `form` type items if the actor already has one.
+        if (this.type === "form" && this.actor?.form) return false;
+    }
+
     /**
      * Prepare a data object which is passed to any Roll formulas which are created related to this Item
      */

--- a/module/sheets/unit.mjs
+++ b/module/sheets/unit.mjs
@@ -34,7 +34,7 @@ export class OHUnitSheet extends ActorSheet {
         context.stance = source.system.stance ?? "";
 
         // Prepare embedded documents
-        context.items = this._prepareItems(actor.items);
+        context.items = this._prepareItems(actor.items.contents);
         context.effects = prepareActiveEffectCategories(actor.effects);
         context.form = actor.items.find((item) => item.type === "form");
 
@@ -57,6 +57,9 @@ export class OHUnitSheet extends ActorSheet {
             skills: { label: "OH.Skills", items: [], type: "skill" },
             weapons: { label: "OH.Weapons", items: [], type: "weapon" },
         };
+
+        // Sort items by their stored sort order
+        items.sort((a, b) => (a.sort || 0) - (b.sort || 0));
 
         for (const item of items) {
             const i = { id: item.id, name: item.name, img: item.img, system: item.system, document: item };

--- a/module/sheets/unit.mjs
+++ b/module/sheets/unit.mjs
@@ -18,6 +18,7 @@ export class OHUnitSheet extends ActorSheet {
     getData() {
         // Retrieve base data structure.
         const context = super.getData();
+        const sourceData = this.actor.toObject();
 
         context.config = CONFIG.OUTERHEAVEN;
 
@@ -26,6 +27,14 @@ export class OHUnitSheet extends ActorSheet {
 
         // Add roll data for TinyMCE editors.
         context.rollData = context.actor.getRollData();
+
+        const stanceEntries = [...this.actor.allApplicableEffects()]
+            .filter((effect) => effect.system.type === "stance")
+            .map((effect) => [effect.getRelativeUUID(null, { toActor: true }), effect.name]);
+        context.stances = Object.fromEntries(stanceEntries);
+        context.stance = sourceData.system.stance ?? "";
+
+        context.form = this.actor.items.find((item) => item.type === "form");
 
         // Prepare items
         this._prepareItems(context);

--- a/module/tests/active-effects.spec.mjs
+++ b/module/tests/active-effects.spec.mjs
@@ -1,0 +1,82 @@
+import { SYSTEM_ID } from "../const.mjs";
+import { createActor, createEffects, createItems, updateSource } from "./utils.mjs";
+
+/**
+ * @param {import("@ethaks/fvtt-quench/lib").Quench} quench
+ */
+export function registerActiveEffectTests(quench) {
+    quench.registerBatch(
+        `${SYSTEM_ID}.active-effects.basic`,
+        (context) => {
+            const { describe, it, assert, expect, should, before, after } = context;
+
+            describe("ActiveEffect types", function () {
+                it("should accept blank type", function () {
+                    const ae = new ActiveEffect.implementation({ name: "Test Effect" });
+                    expect(ae).to.be.an.instanceof(ActiveEffect);
+                });
+
+                it("should accept stance type", function () {
+                    const ae = new ActiveEffect.implementation({
+                        name: "Test Effect",
+                        flags: { outerheaven: { type: "stance" } },
+                    });
+                    expect(ae).to.be.an.instanceof(ActiveEffect);
+                    expect(ae.system.type).to.equal("stance");
+                });
+
+                it("should accept template type", function () {
+                    const ae = new ActiveEffect.implementation({
+                        name: "Test Effect",
+                        flags: { outerheaven: { type: "template" } },
+                    });
+                    expect(ae).to.be.an.instanceof(ActiveEffect);
+                    expect(ae.system.type).to.equal("template");
+                });
+
+                it("should not transfer template type effects", function () {
+                    const actor = createActor();
+                    const [item] = createItems([{ name: "AE Test Armor" }], { parent: actor });
+                    const [effect] = createEffects([{ name: "AE Test Effect", system: { type: "template" } }], {
+                        parent: item,
+                    });
+
+                    expect(effect).to.be.an.instanceof(ActiveEffect);
+                    expect([...actor.allApplicableEffects()]).to.have.lengthOf(0);
+                    expect(actor.items.contents[0].effects).to.have.lengthOf(1);
+                });
+            });
+
+            describe("ActiveEffect suppression", function () {
+                it("should only allow one active stance", async function () {
+                    const actor = createActor({ name: "Stance Test" });
+                    const [item] = createItems([{ name: "Stance Armor" }], { parent: actor });
+                    const [stance1, stance2] = createEffects(
+                        [
+                            { name: "Stance 1", system: { type: "stance" } },
+                            { name: "Stance 2", system: { type: "stance" } },
+                        ],
+                        { parent: item },
+                    );
+
+                    // Both stances should transfer to the actor, but remain suppressed
+                    const actorEffects = [...actor.allApplicableEffects()];
+                    expect(actorEffects).to.have.lengthOf(2);
+                    expect(actorEffects.every((effect) => effect.system.type === "stance")).to.be.true;
+                    expect(actorEffects.every((effect) => effect.isSuppressed)).to.be.true;
+                    expect(actor.system.stance).to.be.null;
+
+                    updateSource(actor, { "system.stance": stance1.getRelativeUUID(null, { toActor: true }) });
+
+                    expect([...actor.allApplicableEffects()]).to.have.lengthOf(2);
+                    expect(actor.system.stance).to.equal(stance1);
+                    expect(stance1.isSuppressed).to.be.false;
+                    expect(stance2.isSuppressed).to.be.true;
+                });
+            });
+        },
+        {
+            displayName: "OUTERHEAVEN: Active Effects",
+        },
+    );
+}

--- a/module/tests/actor-basic.spec.mjs
+++ b/module/tests/actor-basic.spec.mjs
@@ -1,4 +1,5 @@
 import { SYSTEM_ID } from "../const.mjs";
+import { createActor, createItems } from "./utils.mjs";
 
 /**
  * @param {import("@ethaks/fvtt-quench/lib").Quench} quench
@@ -32,6 +33,66 @@ export function registerBasicActorTests(quench) {
                         items: [testItem.toObject()],
                     });
                     expect(actor.system.totalPoints).to.equal(10);
+                });
+            });
+
+            describe("Profile/Defense", function () {
+                it("should initialize with default values", function () {
+                    const actor = createActor();
+                    expect(actor.system.profile.total).to.equal(6);
+                    expect(actor.system.defense.total).to.equal(11);
+                });
+
+                it("should add misc bonuses", function () {
+                    const actor = createActor({ defense: { miscBonus: 5 }, profile: { miscBonus: 5 } });
+                    expect(actor.system.profile.total).to.equal(11);
+                    expect(actor.system.defense.total).to.equal(16);
+                });
+            });
+
+            describe("Armor", function () {
+                it("should initialize with default values", function () {
+                    const actor = createActor();
+                    expect(Object.values(actor.system.armor).every((armor) => armor === 0)).to.be.true;
+                });
+
+                it("should add a single armor bonus", function () {
+                    const actor = createActor();
+                    createItems([{ type: "armor", system: { armorBonuses: [{ armorType: "piercing", value: 10 }] } }], {
+                        parent: actor,
+                    });
+                    expect(actor.system.armor.piercing).to.equal(10);
+                    expect(
+                        Object.entries(actor.system.armor)
+                            .filter(([armor]) => armor !== "piercing")
+                            .every(([, value]) => value === 0),
+                    ).to.be.true;
+                });
+
+                it("should add an 'all' armor bonus", function () {
+                    const actor = createActor();
+                    createItems([{ type: "armor", system: { armorBonuses: [{ armorType: "all", value: 10 }] } }], {
+                        parent: actor,
+                    });
+                    expect(Object.values(actor.system.armor).every((armor) => armor === 10)).to.be.true;
+                });
+
+                it("should add specific an 'all' armor bonuses", function () {
+                    const actor = createActor();
+                    createItems(
+                        [
+                            { type: "armor", system: { armorBonuses: [{ armorType: "piercing", value: 10 }] } },
+                            {
+                                type: "armor",
+                                system: { armorBonuses: [{ armorType: "all", value: 10 }] },
+                            },
+                        ],
+                        {
+                            parent: actor,
+                        },
+                    );
+                    expect(actor.system.armor.piercing).to.equal(20);
+                    expect(actor.system.armor.slashing).to.equal(10);
                 });
             });
         },

--- a/module/tests/actor-basic.spec.mjs
+++ b/module/tests/actor-basic.spec.mjs
@@ -1,0 +1,42 @@
+import { SYSTEM_ID } from "../const.mjs";
+
+/**
+ * @param {import("@ethaks/fvtt-quench/lib").Quench} quench
+ */
+export function registerBasicActorTests(quench) {
+    quench.registerBatch(
+        `${SYSTEM_ID}.actor.basic`,
+        (context) => {
+            const { describe, it, assert, expect, should, before, after } = context;
+
+            describe("Unit point handling", function () {
+                it("should have 100 max unit points", function () {
+                    const actor = new Actor.implementation({
+                        name: "Test Actor",
+                        type: "unit",
+                        system: { maxPoints: 100 },
+                    });
+                    expect(actor.system.maxPoints).to.equal(100);
+                });
+
+                it("should total item points", function () {
+                    const testItem = new Item.implementation({
+                        name: "Test Item",
+                        type: "weapon",
+                        system: { pointCost: 10 },
+                    });
+                    const actor = new Actor.implementation({
+                        name: "Test Actor",
+                        type: "unit",
+                        system: { maxPoints: 100 },
+                        items: [testItem.toObject()],
+                    });
+                    expect(actor.system.totalPoints).to.equal(10);
+                });
+            });
+        },
+        {
+            displayName: "OUTERHEAVEN: Actor Basic",
+        },
+    );
+}

--- a/module/tests/index.mjs
+++ b/module/tests/index.mjs
@@ -1,0 +1,9 @@
+import { registerActiveEffectTests } from "./active-effects.spec.mjs";
+import { registerBasicActorTests } from "./actor-basic.spec.mjs";
+import { registerWeaponAttackTest } from "./weapon-attack.spec.mjs";
+
+Hooks.on("quenchReady", (quench) => {
+    registerBasicActorTests(quench);
+    registerWeaponAttackTest(quench);
+    registerActiveEffectTests(quench);
+});

--- a/module/tests/utils.mjs
+++ b/module/tests/utils.mjs
@@ -1,0 +1,96 @@
+/**
+ * Create a new Actor instance using the provided data and options.
+ *
+ * @param {object} data - Initial data provided to construct the Actor
+ * @param {string} [data.name] - The name of the Actor
+ * @param {string} [data.type] - The type of the Actor
+ * @param {(object | OHItem)[]} [data.items] - An array of Item data objects with which to create embedded Item instances
+ * @param {(object | OHActiveEffect)[]} [data.effects] - An array of ActiveEffect data objects with which to create embedded ActiveEffect instances
+ * @param {object} options - Actor creation options
+ * @returns {OHActor} The constructed Actor instance
+ */
+export function createActor(data = {}, options = {}) {
+    let { name = "Test Actor", type = "unit", items = [], effects = [], ...system } = data;
+
+    items = items.map((item) =>
+        item instanceof foundry.abstract.DataModel ? item.toObject() : new Item.implementation(item).toObject(),
+    );
+    effects = effects.map((effect) =>
+        effect instanceof foundry.abstract.DataModel
+            ? effect.toObject()
+            : new ActiveEffect.implementation(effect).toObject(),
+    );
+
+    return new Actor.implementation({ name, type, items, effects, system }, { ...options, temporary: true });
+}
+
+/**
+ * Create new Item instances using the provided data and options.
+ *
+ * @param {(object | OHItem)[]} data - Initial data provided to construct the Item
+ * @param {object} [options] - Item creation options
+ * @param {Actor} [options.parent=null] - The Actor to which the Item should be embedded
+ * @returns {OHItem[]} The constructed Item instances
+ */
+export function createItems(data = [], options = {}) {
+    const { parent = null, ...rest } = options;
+
+    data = data instanceof Array ? data : [data];
+    data = data.map((item) => {
+        let { name = "Test Item", type = "weapon", effects = [], system = {}, ...itemData } = item;
+        effects = effects.map((effect) =>
+            effect instanceof foundry.abstract.DataModel
+                ? effect.toObject()
+                : new ActiveEffect.implementation(effect).toObject(),
+        );
+        return { name, type, system, effects };
+    });
+
+    const items = data.map((item) => new Item.implementation(item, rest));
+
+    if (parent && parent instanceof foundry.abstract.DataModel) {
+        parent.updateSource({ items: [...parent._source.items, ...items.map((item) => item.toObject())] });
+        parent.reset();
+        return parent.items.contents.slice(-items.length);
+    }
+    return items;
+}
+
+/**
+ * Create new ActiveEffect instances using the provided data and options.
+ *
+ * @param {(object | OHActiveEffect)[]} data - Initial data provided to construct the ActiveEffect
+ * @param {object} [options] - ActiveEffect creation options
+ * @param {Actor | Item} [options.parent=null] - The Actor or Item to which the ActiveEffect should be embedded
+ * @returns {OHActiveEffect[]} The constructed ActiveEffect instances
+ */
+export function createEffects(data = [], options = {}) {
+    const { parent = null, ...rest } = options;
+
+    data = data instanceof Array ? data : [data];
+    data = data.map((effect) => {
+        const { name = "Test Effect", system = {}, ...effectData } = effect;
+        return { name, flags: { outerheaven: system }, ...effectData };
+    });
+
+    const effects = data.map((effect) => new ActiveEffect.implementation(effect), rest);
+
+    if (parent && parent instanceof foundry.abstract.DataModel) {
+        parent.updateSource({
+            effects: [...parent._source.effects, ...effects.map((effect) => effect.toObject())],
+        });
+        parent.parent ? parent.parent.reset() : parent.reset();
+        return parent.effects.contents.slice(-effects.length);
+    }
+
+    return effects;
+}
+
+/**
+ * Update the source data of a {@link foundry.abstract.DataModel} instance and reset it.
+ */
+export function updateSource(doc, data = {}) {
+    const result = doc.updateSource(data);
+    doc.reset();
+    return result;
+}

--- a/module/tests/weapon-attack.spec.mjs
+++ b/module/tests/weapon-attack.spec.mjs
@@ -1,0 +1,57 @@
+import { SYSTEM_ID } from "../const.mjs";
+import { DamageRoll } from "../dice/damage-roll.mjs";
+
+/** @param {import("@ethaks/fvtt-quench/lib").Quench} quench */
+export function registerWeaponAttackTest(quench) {
+    quench.registerBatch(
+        `${SYSTEM_ID}.weapon-attack`,
+        (context) => {
+            const { describe, it, assert, expect, should, before, after } = context;
+
+            describe("Basic Attack", function () {
+                let actor, item, message;
+                const messages = [];
+                before(async function () {
+                    actor = await Actor.create({ name: "Test Actor", type: "unit" });
+                    item = await Item.create(
+                        {
+                            type: "weapon",
+                            name: "Test Weapon",
+                            system: {
+                                damagePerAttack: "1d6 + 1",
+                            },
+                        },
+                        { parent: actor },
+                    );
+                });
+                after(async function () {
+                    await actor.delete();
+                    await ChatMessage.deleteDocuments(messages.map((m) => m.id));
+                });
+
+                it("should create a message", async function () {
+                    message = await item.use();
+                    messages.push(message);
+                    expect(message).to.be.an.instanceof(ChatMessage);
+                    // Check Rolls
+                    expect(message.rolls).to.have.lengthOf(2);
+                });
+
+                it("should create rolls", function () {
+                    expect(message.rolls).to.have.lengthOf(2);
+                    expect(message.rolls[0]).to.be.an.instanceof(Roll);
+                    expect(message.rolls[1]).to.be.an.instanceof(DamageRoll);
+                });
+
+                it("should roll damage", async () => {
+                    expect(message.action.damageRoll).to.be.an.instanceof(DamageRoll);
+                    // Check Damage formula; expects normal crit rules
+                    expect(message.action.damageRoll.formula).to.equal("1d6x + 1");
+                });
+            });
+        },
+        {
+            displayName: "OUTERHEAVEN: Weapon Attack",
+        },
+    );
+}

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -15,6 +15,8 @@ export async function preloadHandlebarsTemplates() {
         "systems/outerheaven/templates/sheets/parts/unit-stats-sidebar.hbs",
         "systems/outerheaven/templates/sheets/parts/unit-stats-defense.hbs",
         "systems/outerheaven/templates/sheets/parts/unit-weapons.hbs",
+        "systems/outerheaven/templates/sheets/parts/item-effects.hbs",
+        "systems/outerheaven/templates/sheets/parts/ae-config.hbs",
         "systems/outerheaven/templates/chat/item-display.hbs",
         "systems/outerheaven/templates/chat/defense-display.hbs",
         "systems/outerheaven/templates/chat/defense-stats-display.hbs",

--- a/outerheaven.mjs
+++ b/outerheaven.mjs
@@ -42,11 +42,16 @@ Hooks.once("init", function () {
         ability: dataModels.OHAbility,
         armor: dataModels.OHArmor,
         equipment: dataModels.OHEquipment,
+        form: dataModels.OHForm,
         skill: dataModels.OHSkill,
         weapon: dataModels.OHWeapon,
     };
     Items.unregisterSheet("core", ItemSheet);
     Items.registerSheet("outerheaven", sheets.OHItemSheet, { makeDefault: true });
+
+    // Active Effects
+    CONFIG.ActiveEffect.legacyTransferral = false;
+    CONFIG.ActiveEffect.documentClass = documents.OHActiveEffect;
 
     // Dice
     CONFIG.Dice.rolls.push(dice.DamageRoll);
@@ -84,6 +89,10 @@ Hooks.on("renderChatLog", (app, html, data) => {
         const targetId = event.currentTarget.dataset.targetId;
         message.action.applyTargetDamage(targetId);
     });
+});
+
+Hooks.on("renderActiveEffectConfig", (app, html, data) => {
+    documents.onRenderActiveEffectConfig(app, html, data);
 });
 
 async function createItemMacro(data, slot) {

--- a/outerheaven.mjs
+++ b/outerheaven.mjs
@@ -23,6 +23,10 @@ globalThis.outerheaven = {
     sheets,
 };
 
+if (import.meta.env.DEV) {
+    await import("./module/tests/index.mjs");
+}
+
 Hooks.once("init", function () {
     console.log("Outer Heaven | Initializing the battlefield...");
 

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -87,7 +87,10 @@
         "Ammo": "Ammo",
         "NoAmmo": "No Ammo",
         "Uses": "Uses",
+        "Actions": "Actions",
         "ActionsToFire": "Actions to fire",
+        "Max": "Max",
+        "PowerCost": "Power Cost",
         "Attack": "Attack",
         "Reload": "Reload",
         "WeaponReloaded": "Weapon has been reloaded.",
@@ -96,8 +99,14 @@
         "ArmorPenetration": "Armor Penetration",
         "TotalAP": "Total AP",
         "Damage": "Damage",
+        "Benefits": "Benefits",
         "Properties": "Properties",
 
-        "Weapons": "Weapons"
+        "Defenses": "Defenses",
+        "Armor": "Armor",
+        "Weapons": "Weapons",
+        "Equipment": "Equipment",
+        "Skills": "Skills",
+        "Abilities": "Abilities"
     }
 }

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -5,7 +5,8 @@
             "armor": "Armor",
             "equipment": "Equipment",
             "skill": "Skill",
-            "weapon": "Weapon"
+            "weapon": "Weapon",
+            "form": "Form"
         },
         "Actor": {
             "unit": "Unit"
@@ -60,6 +61,26 @@
             "Ranged": "Ranged"
         },
 
+        "Effects": "Effects",
+        "EffectType": "Effect Type",
+        "EffectTypes": {
+            "Stance": "Stance",
+            "Template": "Template",
+            "Hint": "Types the system attaches special behavior to."
+        },
+
+        "Create": "Create",
+        "OpenCompendium": "Open Compendium",
+        "Edit": "Edit",
+        "Delete": "Delete",
+        "Details": "Details",
+
+        "Grit": "Grit",
+        "Awareness": "Awareness",
+        "Morale": "Morale",
+
+        "Stance": "Stance",
+
         "Targets": "Targets",
         "Shots": "Shots",
         "Strikes": "Strikes",
@@ -67,6 +88,8 @@
         "NoAmmo": "No Ammo",
         "Uses": "Uses",
         "ActionsToFire": "Actions to fire",
+        "Attack": "Attack",
+        "Reload": "Reload",
         "WeaponReloaded": "Weapon has been reloaded.",
         "Range": "Range",
         "RangeModifier": "Range Modifier",

--- a/static/template.json
+++ b/static/template.json
@@ -3,7 +3,7 @@
         "types": ["unit"]
     },
     "Item": {
-        "types": ["weapon", "equipment", "ability", "skill", "armor"],
+        "types": ["weapon", "equipment", "ability", "skill", "armor", "form"],
         "htmlFields": ["description"]
     }
 }

--- a/static/templates/sheets/ability-sheet.hbs
+++ b/static/templates/sheets/ability-sheet.hbs
@@ -1,36 +1,89 @@
 <form class="{{cssClass}}" autocomplete="off">
     <header class="sheet-header">
-        <img src="{{item.img}}" data-edit="img" title="{{item.name}}" height="64" width="64"/>
-        <h1><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>
+        <img src="{{item.img}}" data-edit="img" title="{{item.name}}" height="64" width="64" />
+        <h1><input name="name" type="text" value="{{item.name}}" placeholder="Name" /></h1>
     </header>
-    <div>
-        <div class="itemSection">
-            <table class="center">
-                <tr>
-                    <th>Actions to Use</th>
-                    <th>Uses</th>
-                    <th>Max Uses</th>
-                    <th>Power Cost</th>
-                </tr>
-                <tr>
-                    <td><input class="mediumInput" type="text" name="system.actionsToUse" value="{{system.actionsToUse}}" data-dtype="Number" /></td>
-                    <td><input class="mediumInput" type="text" name="system.capacity.value" value="{{system.capacity.value}}" data-dtype="Number" /></td>
-                    <td><input class="mediumInput" type="text" name="system.capacity.max" value="{{system.capacity.max}}" data-dtype="Number" /></td>
-                    <td><input class="mediumInput" type="text" name="system.powerCost" value="{{system.powerCost}}" data-dtype="Number" /></td>
-                </tr>
-            </table>
+
+    {{! Navigation }}
+    <nav class="sheet-tabs tabs" data-group="main" aria-role="Form Tab Navigation">
+        <a class="item" data-tab="details">{{localize "OH.Details"}}</a>
+        <a class="item" data-tab="effects">{{localize "OH.Effects"}}</a>
+    </nav>
+
+    <section class="content">
+        {{! Description tab }}
+        <div class="tab" data-group="main" data-tab="details">
+            <div class="itemSection">
+                <table class="center">
+                    <tr>
+                        <th>Actions to Use</th>
+                        <th>Uses</th>
+                        <th>Max Uses</th>
+                        <th>Power Cost</th>
+                    </tr>
+                    <tr>
+                        <td>
+                            <input
+                                class="mediumInput"
+                                type="text"
+                                name="system.actionsToUse"
+                                value="{{system.actionsToUse}}"
+                            />
+                        </td>
+                        <td>
+                            <input
+                                class="mediumInput"
+                                type="text"
+                                name="system.capacity.value"
+                                value="{{system.capacity.value}}"
+                            />
+                        </td>
+                        <td>
+                            <input
+                                class="mediumInput"
+                                type="text"
+                                name="system.capacity.max"
+                                value="{{system.capacity.max}}"
+                            />
+                        </td>
+                        <td>
+                            <input
+                                class="mediumInput"
+                                type="text"
+                                name="system.powerCost"
+                                value="{{system.powerCost}}"
+                            />
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <div class="itemSection description">
+                {{editor
+                    description
+                    target="system.description"
+                    button=true
+                    engine="prosemirror"
+                    owner=owner
+                    editable=editable
+                }}
+            </div>
+
+            <div class="itemSection">
+                <p class="floatLeft">
+                    Tags :
+                    <input class="mediumInput" type="text" name="system.tags" value="{{system.tags}}" />
+                </p>
+                <p class="floatRight">
+                    Point cost : <input class="smallInput" type="text" name="system.pointCost" value="{{system.pointCost}}" />
+                    Ignore cost : <input class="vCenter" type="checkbox" name="system.ignoreCost" {{checked system.ignoreCost}} />
+                </p>
+            </div>
         </div>
-        <div class="itemSection">
-            {{editor description target="system.description" button=true engine="prosemirror" owner=owner editable=editable}}
+
+        {{! Effects tab }}
+        <div class="tab" data-group="main" data-tab="effects">
+            {{>"oh.item-effects" }}
         </div>
-        <div>
-            <p class="floatLeft">
-                Tags : <input class="mediumInput" type="text" name="system.tags" value="{{system.tags}}" />
-            </p>
-            <p class="floatRight">
-                Point cost : <input class="smallInput" type="text" name="system.pointCost" value="{{system.pointCost}}" data-dtype="Number" />
-                Ignore cost : <input class="vCenter" type="checkbox" name="system.ignoreCost" {{checked system.ignoreCost}} />
-            </p>
-        </div>
-    </div>
+    </section>
 </form>

--- a/static/templates/sheets/armor-sheet.hbs
+++ b/static/templates/sheets/armor-sheet.hbs
@@ -3,40 +3,48 @@
         <img src="{{item.img}}" data-edit="img" title="{{item.name}}" height="64" width="64" />
         <h1><input name="name" type="text" value="{{item.name}}" placeholder="Name" /></h1>
     </header>
-    <div>
-        <div class="itemSection">
-            <a class="armorBonus-create" title="New"><i class="fas fa-plus"></i> New Armor Bonus</a>
-            <table class="item-list">
-                {{#each system.armorBonuses as |item id|}}
-                    <tr class="item" data-index={{id}}>
-                        <td>
-                            <input
-                                class="mediumInput"
-                                type="text"
-                                name="system.armorBonuses.{{id}}.value"
-                                value="{{item.value}}"
-                                data-dtype="Number"
-                            />
-                            <select name="system.armorBonuses.{{id}}.armorType">
-                                {{selectOptions @root.config.armorTypes selected=item.armorType localize=true}}
-                            </select>
-                        </td>
-                        <td>
-                            <a
-                                class="armorBonus-delete"
-                                data-value="{{item.value}}"
-                                data-type="{{item.armorType}}"
-                                title="Delete"
-                            ><i class="fas fa-trash"></i></a>
-                        </td>
-                    </tr>
-                {{/each}}
-            </table>
-        </div>
-        <div class="itemSection">
+
+    {{!-- Navigation --}}
+    <nav class="sheet-tabs tabs" data-group="main" aria-role="Form Tab Navigation">
+      <a class="item" data-tab="details">{{localize "OH.Details"}}</a>
+      <a class="item" data-tab="effects">{{localize "OH.Effects"}}</a>
+    </nav>
+
+  {{!-- Tab content --}}
+  <section class="content">
+    {{!-- Details tab --}}
+    <div class="tab" data-group="main" data-tab="details">
+      <div class="flexrow">
+        {{!-- Benefits --}}
+        <div class="itemSection benefits">
             Benefits
             <textarea name="system.benefitsDescription">{{system.benefitsDescription}}</textarea>
         </div>
+
+        {{!-- Armor bonuses --}}
+        <div class="itemSection armor-bonuses">
+            <a class="armorBonus-create" title="New"><i class="fas fa-plus"></i> New Armor Bonus</a>
+            <ul class="item-list">
+                {{#each system.armorBonuses as |item id|}}
+                    <li class="item flexrow" data-index={{id}}>
+                        <input
+                            class="mediumInput"
+                            type="number"
+                            name="system.armorBonuses.{{id}}.value"
+                            value="{{item.value}}"
+                        />
+                        <select name="system.armorBonuses.{{id}}.armorType">
+                            {{selectOptions @root.config.armorTypes selected=item.armorType localize=true}}
+                        </select>
+                        <div class="item-controls">
+                            <a class="armorBonus-delete" title="Delete"><i class="fas fa-trash"></i></a>
+                        </div>
+                    </li>
+                {{/each}}
+            </ul>
+        </div>
+      </div>
+
         <hr />
         <div class="itemSection">
             {{editor description target="system.description" button=true engine="prosemirror" owner=owner editable=editable}}
@@ -60,4 +68,10 @@
             </p>
         </div>
     </div>
+
+    {{!-- Effects tab --}}
+    <div class="tab" data-group="main" data-tab="effects">
+      {{>"oh.item-effects"}}
+    </div>
+  </section>
 </form>

--- a/static/templates/sheets/equipment-sheet.hbs
+++ b/static/templates/sheets/equipment-sheet.hbs
@@ -1,36 +1,91 @@
 <form class="{{cssClass}}" autocomplete="off">
     <header class="sheet-header">
-        <img src="{{item.img}}" data-edit="img" title="{{item.name}}" height="64" width="64"/>
-        <h1><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>
+        <img src="{{item.img}}" data-edit="img" title="{{item.name}}" height="64" width="64" />
+        <h1><input name="name" type="text" value="{{item.name}}" placeholder="Name" /></h1>
     </header>
-    <div>
-        <div class="itemSection">
-            <table class="center">
-                <tr>
-                    <th>Actions to Use</th>
-                    <th>Uses</th>
-                    <th>Max Uses</th>
-                    <th>Power Cost</th>
-                </tr>
-                <tr>
-                    <td><input class="mediumInput" type="text" name="system.actionsToUse" value="{{system.actionsToUse}}" data-dtype="Number" /></td>
-                    <td><input class="mediumInput" type="text" name="system.capacity.value" value="{{system.capacity.value}}" data-dtype="Number" /></td>
-                    <td><input class="mediumInput" type="text" name="system.capacity.max" value="{{system.capacity.max}}" data-dtype="Number" /></td>
-                    <td><input class="mediumInput" type="text" name="system.powerCost" value="{{system.powerCost}}" data-dtype="Number" /></td>
-                </tr>
-            </table>
+
+    {{! Navigation }}
+    <nav class="sheet-tabs tabs" data-group="main" aria-role="Form Tab Navigation">
+        <a class="item" data-tab="details">{{localize "OH.Details"}}</a>
+        <a class="item" data-tab="effects">{{localize "OH.Effects"}}</a>
+    </nav>
+
+    <section class="content">
+        <div class="tab" data-group="main" data-tab="details">
+            <div class="itemSection">
+                <table class="center">
+                    <tr>
+                        <th>Actions to Use</th>
+                        <th>Uses</th>
+                        <th>Max Uses</th>
+                        <th>Power Cost</th>
+                    </tr>
+                    <tr>
+                        <td>
+                            <input
+                                class="mediumInput"
+                                type="text"
+                                name="system.actionsToUse"
+                                value="{{system.actionsToUse}}"
+                                data-dtype="Number"
+                            />
+                        </td>
+                        <td>
+                            <input
+                                class="mediumInput"
+                                type="text"
+                                name="system.capacity.value"
+                                value="{{system.capacity.value}}"
+                                data-dtype="Number"
+                            />
+                        </td>
+                        <td>
+                            <input
+                                class="mediumInput"
+                                type="text"
+                                name="system.capacity.max"
+                                value="{{system.capacity.max}}"
+                                data-dtype="Number"
+                            />
+                        </td>
+                        <td>
+                            <input
+                                class="mediumInput"
+                                type="text"
+                                name="system.powerCost"
+                                value="{{system.powerCost}}"
+                                data-dtype="Number"
+                            />
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <div class="itemSection description">
+                {{editor
+                    description
+                    target="system.description"
+                    button=true
+                    engine="prosemirror"
+                    owner=owner
+                    editable=editable
+                }}
+            </div>
+
+            <div>
+                <p class="floatLeft">
+                    Tags : <input class="mediumInput" type="text" name="system.tags" value="{{system.tags}}" />
+                </p>
+                <p class="floatRight">
+                    Point cost : <input class="smallInput" type="text" name="system.pointCost" value="{{system.pointCost}}" />
+                    Ignore cost : <input class="vCenter" type="checkbox" name="system.ignoreCost" {{checked system.ignoreCost}} />
+                </p>
+            </div>
         </div>
-        <div class="itemSection">
-            {{editor description target="system.description" button=true engine="prosemirror" owner=owner editable=editable}}
+
+        {{! Effects tab }}
+        <div class="tab" data-group="main" data-tab="effects">
+            {{>"oh.item-effects"}}
         </div>
-        <div>
-            <p class="floatLeft">
-                Tags : <input class="mediumInput" type="text" name="system.tags" value="{{system.tags}}" />
-            </p>
-            <p class="floatRight">
-                Point cost : <input class="smallInput" type="text" name="system.pointCost" value="{{system.pointCost}}" data-dtype="Number" />
-                Ignore cost : <input class="vCenter" type="checkbox" name="system.ignoreCost" {{checked system.ignoreCost}} />
-            </p>
-        </div>
-    </div>
+    </section>
 </form>

--- a/static/templates/sheets/form-sheet.hbs
+++ b/static/templates/sheets/form-sheet.hbs
@@ -1,0 +1,8 @@
+<form class="{{cssClass}}" autocomplete="off">
+  <header class="sheet-header">
+    <img src="{{item.img}}" data-edit="img" title="{{item.name}}" height="64" width="64"/>
+    <h1><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>
+  </header>
+
+  {{>"oh.item-effects"}}
+</form>

--- a/static/templates/sheets/parts/ae-config.hbs
+++ b/static/templates/sheets/parts/ae-config.hbs
@@ -1,0 +1,7 @@
+<div class="form-group">
+  <label>{{localize "OH.EffectType"}}</label>
+  <select name="flags.outerheaven.type">
+    {{selectOptions config.effectTypes selected=system.type blank="" localize=true}}
+  </select>
+  <p class="hint">{{localize "OH.EffectTypes.Hint"}}</p>
+</div>

--- a/static/templates/sheets/parts/item-effects.hbs
+++ b/static/templates/sheets/parts/item-effects.hbs
@@ -8,7 +8,7 @@
 
     <ol class="effect-list">
         {{#each activeEffects as |effect id|}}
-            <li class="item effect flexrow" data-id="{{effect._id}}">
+            <li class="effect flexrow" data-effect-id="{{effect._id}}">
                 <img src="{{effect.img}}" alt="{{effect.name}}" class="icon" />
                 <span class="name">{{effect.name}}</span>
                 <div class="item-controls" data-type="ActiveEffect">

--- a/static/templates/sheets/parts/item-effects.hbs
+++ b/static/templates/sheets/parts/item-effects.hbs
@@ -1,0 +1,21 @@
+<section class="effects flexcol">
+    <header class="effect-list-header flexrow">
+        <div class="name">Active Effects</div>
+        <div class="item-controls" data-type="ActiveEffect">
+            <a class="item-create" data-action="create" data-tooltip="New Effect"><i class="fas fa-plus"></i></a>
+        </div>
+    </header>
+
+    <ol class="effect-list">
+        {{#each activeEffects as |effect id|}}
+            <li class="item effect flexrow" data-id="{{effect._id}}">
+                <img src="{{effect.img}}" alt="{{effect.name}}" class="icon" />
+                <span class="name">{{effect.name}}</span>
+                <div class="item-controls" data-type="ActiveEffect">
+                    <a data-action="edit" data-tooltip="OH.Edit"><i class="fas fa-edit"></i></a>
+                    <a data-action="delete" data-tooltip="OH.Delete"><i class="fas fa-trash"></i></a>
+                </div>
+            </li>
+        {{/each}}
+    </ol>
+</section>

--- a/static/templates/sheets/parts/unit-abilities.hbs
+++ b/static/templates/sheets/parts/unit-abilities.hbs
@@ -1,47 +1,41 @@
-<div class="section">
-    <div>
-        <p class="floatLeft"><b><u>Abilities</u></b></p>
-        <p class="floatRight">
-            <a class="item-create" data-type="ability" title="New"><i class="fas fa-plus"></i></a>
-            <a class="item-import" title="Add from compendium"><i class="fas fa-folder-plus"></i></a>
-        </p>
-    </div>
-    {{#if abilities}}
-        <table class="item-list">
-            <tr>
-                <th>Ability</th>
-                <th>Actions</th>
-                <th>Uses</th>
-                <th>Max</th>
-                <th>Power cost</th>
-                <th></th>
-            </tr>
-            {{#each abilities as |item id|}}
-                <tr class="item center" data-item-id="{{item._id}}">
-                    <td class="left">
-                        <div class="flexCenter">
-                            <img src="{{item.img}}" title="{{item.name}}" width="24" height="24" />
-                            <div style="margin-left: 5px"><a class="item-display">{{item.name}}</a></div>
-                        </div>
-                    </td>
-                    <td>{{#if item.system.actionsToUse}}{{item.system.actionsToUse}} action(s){{/if}}</td>
-                    <td>{{#if item.system.capacity.value}}
-                            <input
-                                class="smallInput inline-edit"
-                                data-field="system.capacity.value"
-                                type="text"
-                                value="{{item.system.capacity.value}}"
-                                data-dtype="Number"
-                            />
-                        {{/if}}</td>
-                    <td>{{#if item.system.capacity.max}}{{item.system.capacity.max}}{{/if}}</td>
-                    <td>{{#if item.system.powerCost}}{{item.system.powerCost}}{{/if}}</td>
-                    <td class="floatRight">
-                        <a class="item-edit" title="Edit"><i class="fas fa-edit"></i></a>
-                        <a class="item-delete" title="Delete"><i class="fas fa-trash"></i></a>
-                    </td>
-                </tr>
-            {{/each}}
-        </table>
-    {{/if}}
-</div>
+<section class="items abilities flexcol">
+    <header class="item-list-header flexrow">
+        <div class="name">{{localize label}}</div>
+        <div class="actions">{{localize "OH.Actions"}}</div>
+        <div class="uses">{{localize "OH.Uses"}}</div>
+        <div class="max">{{localize "OH.Max"}}</div>
+        <div class="power-cost">{{localize "OH.PowerCost"}}</div>
+        <div class="item-controls flexrow">
+            <a class="item-create" data-type="{{type}}" data-tooltip="{{localize "OH.Create"}}"><i class="fas fa-plus"></i></a>
+            <a class="item-import" data-tooltip="OH.OpenCompendium"><i class="fas fa-folder-plus"></i></a>
+        </div>
+    </header>
+
+    <ol class="item-list">
+        {{#each items as |item id|}}
+            <li class="item flexrow" data-item-id="{{item.id}}">
+                <div class="name flexrow">
+                    <img class="icon" src="{{item.img}}" title="{{item.name}}"/>
+                    <span>{{item.name}}</span>
+                </div>
+
+                <div class="actions">{{ifThen item.system.actionsToUse item.system.actionsToUse ""}}</div>
+
+                <div class="uses">
+                    {{#if item.system.capacity.value}}
+                        <input class="smallInput inline-edit" data-field="system.capacity.value" type="text" value="{{item.system.capacity.value}}" />
+                    {{/if}}
+                </div>
+
+                <div class="max">{{ifThen item.system.capacity.max item.system.capacity.max ""}}</div>
+
+                <div class="power-cost">{{ifThen item.system.powerCost item.system.powerCost ""}}</div>
+
+                <div class="item-controls">
+                    <a class="item-edit" data-tooltip="OH.Edit"><i class="fas fa-edit"></i></a>
+                    <a class="item-delete" data-tooltip="OH.Delete"><i class="fas fa-trash"></i></a>
+                </div>
+            </li>
+        {{/each}}
+    </ol>
+</section>

--- a/static/templates/sheets/parts/unit-defenses.hbs
+++ b/static/templates/sheets/parts/unit-defenses.hbs
@@ -1,33 +1,35 @@
-<div class="section">
-    <div>
-        <p class="floatLeft"><b><u>Defenses</u></b></p>
-        <p class="floatRight">
-            <a class="item-create" data-type="armor" title="New"><i class="fas fa-plus"></i></a>
-            <a class="item-import" title="Add from compendium"><i class="fas fa-folder-plus"></i></a>
-        </p>
-    </div>
-    {{#if defenses}}
-        <table class="item-list">
-            <tr>
-                <th>Item</th>
-                <th>Armor</th>
-                <th>Benefits</th>
-                <th></th>
-            </tr>
-            {{#each defenses as |item id|}}
-                <tr class="item center" data-item-id="{{item._id}}">
-                    <td class="left"><div class="flexCenter">
-                            <img src="{{item.img}}" title="{{item.name}}" width="24" height="24" />
-                            <div style="margin-left: 5px"><a class="item-display">{{item.name}}</a></div></div></td>
-                    <td>{{#if item.armorBonusString}}{{item.armorBonusString}}{{/if}}</td>
-                    <td>{{#if item.system.benefitsDescription}}
-                            <p class="descMaxLength">{{item.system.benefitsDescription}}</p>{{/if}}</td>
-                    <td class="floatRight">
-                        <a class="item-edit" title="Edit"><i class="fas fa-edit"></i></a>
-                        <a class="item-delete" title="Delete"><i class="fas fa-trash"></i></a>
-                    </td>
-                </tr>
-            {{/each}}
-        </table>
-    {{/if}}
-</div>
+<section class="items defenses flexcol">
+    <header class="item-list-header flexrow">
+        <div class="name">{{localize label}}</div>
+        <div class="armor">{{localize "OH.Armor"}}</div>
+        <div class="benefits">{{localize "OH.Benefits"}}</div>
+        <div class="item-controls flexrow">
+            <a class="item-create" data-type="{{type}}" data-tooltip="{{localize "OH.Create"}}"><i class="fas fa-plus"></i></a>
+            <a class="item-import" data-tooltip="OH.OpenCompendium"><i class="fas fa-folder-plus"></i></a>
+        </div>
+    </header>
+
+    <ol class="item-list">
+        {{#each items as |item id|}}
+            <li class="item flexrow" data-item-id="{{item.id}}">
+                <div class="name flexrow">
+                    <img class="icon" src="{{item.img}}" title="{{item.name}}"/>
+                    <span>{{item.name}}</span>
+                </div>
+
+                <div class="armor">{{#if item.armorBonusString}}{{item.armorBonusString}}{{/if}}</div>
+
+                <div class="benefits">
+                    {{#if item.system.benefitsDescription}}
+                        <span class="descMaxLength">{{item.system.benefitsDescription}}</span>
+                    {{/if}}
+                </div>
+
+                <div class="item-controls">
+                    <a class="item-edit" data-tooltip="OH.Edit"><i class="fas fa-edit"></i></a>
+                    <a class="item-delete" data-tooltip="OH.Delete"><i class="fas fa-trash"></i></a>
+                </div>
+            </li>
+        {{/each}}
+    </ol>
+</section>

--- a/static/templates/sheets/parts/unit-items.hbs
+++ b/static/templates/sheets/parts/unit-items.hbs
@@ -1,33 +1,49 @@
-<div class="section">
-    <div>
-        <p class="floatLeft"><b><u>Equipment</u></b></p>
-        <p class="floatRight">
-            <a class="item-create" data-type="equipment" title="New"><i class="fas fa-plus"></i></a> <a class="item-import" title="Add from compendium"><i class="fas fa-folder-plus"></i></a>
-        </p>
-    </div>
-    {{#if equipments}}
-    <table class="item-list">
-        <tr>
-            <th>Item</th>
-            <th>Actions</th>
-            <th>Uses</th>
-            <th>Max</th>
-            <th>Power cost</th>
-            <th></th>
-        </tr>
-    {{#each equipments as |item id|}}
-        <tr class="item center" data-item-id="{{item._id}}">
-            <td class="left"><div class="flexCenter"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24"/><div style="margin-left: 5px"><a class="item-display">{{item.name}}</a></div></div></td>
-            <td>{{#if item.system.actionsToUse}}{{item.system.actionsToUse}} action(s){{/if}}</td>
-            <td>{{#if item.system.capacity.value}}<input class="smallInput inline-edit" data-field="system.capacity.value" type="text" value="{{item.system.capacity.value}}" data-dtype="Number" />{{/if}}</td>
-            <td>{{#if item.system.capacity.max}}{{item.system.capacity.max}}{{/if}}</td>
-            <td>{{#if item.system.powerCost}}{{item.system.powerCost}}{{/if}}</td>
-            <td class="floatRight">
-                <a class="item-edit" title="Edit"><i class="fas fa-edit"></i></a>
-                <a class="item-delete" title="Delete"><i class="fas fa-trash"></i></a>
-            </td>
-        </tr>
-    {{/each}}
-    </table>
-    {{/if}}
-</div>
+<section class="items equipment flexcol">
+    <header class="item-list-header flexrow">
+        <div class="name">{{localize label}}</div>
+        <div class="actions">{{localize "OH.Actions"}}</div>
+        <div class="uses">{{localize "OH.Uses"}}</div>
+        <div class="max">{{localize "OH.Max"}}</div>
+        <div class="power-cost">{{localize "OH.PowerCost"}}</div>
+        <div class="item-controls flexrow">
+            <a class="item-create" data-type="{{type}}" data-tooltip="{{localize "OH.Create"}}"><i class="fas fa-plus"></i></a>
+            <a class="item-import" data-tooltip="OH.OpenCompendium"><i class="fas fa-folder-plus"></i></a>
+        </div>
+    </header>
+
+    <ol class="item-list">
+        {{#each items as |item id|}}
+            <li class="item flexrow" data-item-id="{{item.id}}">
+                <div class="name flexrow">
+                    <img class="icon" src="{{item.img}}" title="{{item.name}}"/>
+                    <span>{{item.name}}</span>
+                </div>
+
+                <div class="actions">{{ifThen item.system.actionsToUse item.system.actionsToUse ""}}</div>
+
+                <div class="uses">
+                    {{#if item.system.capacity.value}}
+                        <input
+                            class="smallInput inline-edit"
+                            data-field="system.capacity.value"
+                            type="number"
+                            step="1"
+                            min="0"
+                            max="{{item.system.capacity.max}}"
+                            value="{{item.system.capacity.value}}" 
+                        />
+                    {{/if}}
+                </div>
+
+                <div class="max">{{ifThen item.system.capacity.max item.system.capacity.max ""}}</div>
+
+                <div class="power-cost">{{ifThen item.system.powerCost item.system.powerCost ""}}</div>
+
+                <div class="item-controls">
+                    <a class="item-edit" data-tooltip="OH.Edit"><i class="fas fa-edit"></i></a>
+                    <a class="item-delete" data-tooltip="OH.Delete"><i class="fas fa-trash"></i></a>
+                </div>
+            </li>
+        {{/each}}
+    </ol>
+</section>

--- a/static/templates/sheets/parts/unit-skills.hbs
+++ b/static/templates/sheets/parts/unit-skills.hbs
@@ -1,27 +1,32 @@
-<div class="section">
-    <div>
-        <p class="floatLeft"><b><u>Skills</u></b></p>
-        <p class="floatRight">
-            <a class="item-create" data-type="skill" title="New"><i class="fas fa-plus"></i></a> <a class="item-import" title="Add from compendium"><i class="fas fa-folder-plus"></i></a>
-        </p>
-    </div>
-    {{#if skills}}
-    <table class="item-list">
-        <tr>
-            <th>Skill</th>
-            <th>Benefits</th>
-            <th></th>
-        </tr>
-    {{#each skills as |item id|}}
-        <tr class="item center" data-item-id="{{item._id}}">
-            <td class="left"><div class="flexCenter"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24"/><div style="margin-left: 5px"><a class="item-display">{{item.name}}</a></div></div></td>
-            <td>{{#if item.system.benefitsDescription}}<p class="descMaxLength">{{item.system.benefitsDescription}}</p>{{/if}}</td>
-            <td class="floatRight">
-                <a class="item-edit" title="Edit"><i class="fas fa-edit"></i></a>
-                <a class="item-delete" title="Delete"><i class="fas fa-trash"></i></a>
-            </td>
-        </tr>
-    {{/each}}
-    </table>
-    {{/if}}
-</div>
+<section class="items skills flexcol">
+    <header class="item-list-header flexrow">
+        <div class="name">{{localize label}}</div>
+        <div class="benefits">{{localize "OH.Benefits"}}</div>
+        <div class="item-controls flexrow">
+            <a class="item-create" data-type="{{type}}" data-tooltip="{{localize "OH.Create"}}"><i class="fas fa-plus"></i></a>
+            <a class="item-import" data-tooltip="OH.OpenCompendium"><i class="fas fa-folder-plus"></i></a>
+        </div>
+    </header>
+
+    <ol class="item-list">
+        {{#each items as |item id|}}
+            <li class="item flexrow" data-item-id="{{item.id}}">
+                <div class="name flexrow">
+                    <img class="icon" src="{{item.img}}" title="{{item.name}}"/>
+                    <span>{{item.name}}</span>
+                </div>
+
+                <div class="benefits">
+                    {{#if item.system.benefitsDescription}}
+                        <span class="descMaxLength">{{item.system.benefitsDescription}}</span>
+                    {{/if}}
+                </div>
+
+                <div class="item-controls">
+                    <a class="item-edit" data-tooltip="OH.Edit"><i class="fas fa-edit"></i></a>
+                    <a class="item-delete" data-tooltip="OH.Delete"><i class="fas fa-trash"></i></a>
+                </div>
+            </li>
+        {{/each}}
+    </ol>
+</section>

--- a/static/templates/sheets/parts/unit-stats-defense.hbs
+++ b/static/templates/sheets/parts/unit-stats-defense.hbs
@@ -1,4 +1,4 @@
-<div>
+<div class="flexcol">
     <table>
         <tr>
             <th><button class="displayDefenses">Show</button></th>
@@ -76,6 +76,8 @@
             </th>
         </tr>
     </table>
+
+    {{! Saves }}
     <table>
         <th>Grit : <input class="smallInput" type="text" name="system.saves.grit" value="{{system.saves.grit}}" /></th>
         <th>Awareness :

--- a/static/templates/sheets/parts/unit-stats-sidebar.hbs
+++ b/static/templates/sheets/parts/unit-stats-sidebar.hbs
@@ -35,6 +35,36 @@
         Speed : <input title="system.speed" class="smallInput" style="font-size: 18px;" type="text" name="system.speed" value="{{system.speed}}" data-dtype="Number" />
     </div>
     <br />
+
+    {{! Form Item }}
+    <div class="form-item form-group">
+        <label>{{localize "TYPES.Item.form"}}</label>
+        <div class="item-list">
+            <div class="item flexrow" data-item-id="{{ifThen form form.id ''}}">
+                <div class="name flexrow">
+                    {{#if form}}
+                        <img class="icon" src="{{form.img}}" title="{{form.name}}" />
+                        <span>{{form.name}}</span>
+                    {{/if}}
+                </div>
+                <div class="item-controls">
+                    {{#if form}}
+                        <a class="item-edit" data-tooltip="OH.Edit"><i class="fas fa-edit"></i></a>
+                        <a class="item-delete" data-tooltip="OH.Delete"><i class="fas fa-trash"></i></a>
+                    {{else}}
+                        <a class="item-create" data-type="form" data-tooltip="OH.Create"><i class="fas fa-plus"></i></a>
+                    {{/if}}
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="stance form-group">
+      <label>{{localize "OH.Stance"}}</label>
+      <select name="system.stance">
+        {{selectOptions stances selected=stance blank=""}}
+      </select>
+    </div>
         <table class="item-list">
         {{#each effects as |section sid|}}
         <tr data-effect-type="{{section.type}}">

--- a/static/templates/sheets/parts/unit-weapons.hbs
+++ b/static/templates/sheets/parts/unit-weapons.hbs
@@ -8,8 +8,8 @@
     <div class="damage">Damage</div>
     <div class="ammo">Ammo</div>
     <div class="item-controls flexrow">
-      <a class="item-create" data-type="{{inventory.weapons.type}}" title="New"><i class="fas fa-plus"></i></a>
-      <a class="item-import" title="Add from compendium"><i class="fas fa-folder-plus"></i></a>
+      <a class="item-create" data-type="{{inventory.weapons.type}}" data-tooltip="Create"><i class="fas fa-plus"></i></a>
+      <a class="item-import" data-tooltip="OH.OpenCompendium"><i class="fas fa-folder-plus"></i></a>
     </div>
   </header>
 
@@ -25,7 +25,7 @@
 
         {{!-- Use link for weapon attacks --}}
         <div class="use">
-          <a class="use-weapon">
+          <a class="use-weapon" data-tooltip="OH.Attack">
             {{#if (eq item.system.weaponType "ranged")}}<i class="fas fa-gun"></i>{{/if}}
             {{#if (eq item.system.weaponType "melee")}}<i class="fas fa-sword"></i>{{/if}}
           </a>
@@ -46,7 +46,7 @@
         <div class="ammo flexrow">
           <div class="reload">
             {{#if item.document.canReload}}
-              <a title="Reload"><img class="icon" src="systems/outerheaven/icons/machine-gun-magazine.svg"></i></a>
+              <a data-tooltip="OH.Reload"><img class="icon" src="systems/outerheaven/icons/machine-gun-magazine.svg"></i></a>
             {{/if}}
           </div>
           <input type="number" value={{item.document.system.capacity.value}} step="1" min="0" max="{{item.system.capacity.max}}" data-field="system.capacity.value" class="inline-edit"/>
@@ -55,8 +55,8 @@
 
         {{!-- Common item controls --}}
         <div class="item-controls">
-          <a class="item-edit" title="Edit"><i class="fas fa-edit"></i></a>
-          <a class="item-delete" title="Delete"><i class="fas fa-trash"></i></a>
+          <a class="item-edit" data-tooltip="OH.Edit"><i class="fas fa-edit"></i></a>
+          <a class="item-delete" data-tooltip="OH.Delete"><i class="fas fa-trash"></i></a>
         </div>
       </li>
     {{/each}}

--- a/static/templates/sheets/parts/unit-weapons.hbs
+++ b/static/templates/sheets/parts/unit-weapons.hbs
@@ -1,22 +1,22 @@
 <section class="items weapons flexcol">
   {{!-- Header row, mirroring the contents of an item list element --}}
   <header class="item-list-header flexrow">
-    <div class="name">{{localize inventory.weapons.label}}</div>
+    <div class="name">{{localize label}}</div>
     <div class="use"></div>
     <div class="actions">ATF</div>
     <div class="attack-bonus">Atk B.</div>
     <div class="damage">Damage</div>
     <div class="ammo">Ammo</div>
     <div class="item-controls flexrow">
-      <a class="item-create" data-type="{{inventory.weapons.type}}" data-tooltip="Create"><i class="fas fa-plus"></i></a>
+      <a class="item-create" data-type="{{type}}" data-tooltip="Create"><i class="fas fa-plus"></i></a>
       <a class="item-import" data-tooltip="OH.OpenCompendium"><i class="fas fa-folder-plus"></i></a>
     </div>
   </header>
 
   <ol class="item-list">
-    {{#each inventory.weapons.items as |item id|}}
+    {{#each items as |item id|}}
       {{!-- Each individual item's list element --}}
-      <li class="item flexrow" data-item-id="{{item._id}}">
+      <li class="item flexrow" data-item-id="{{item.id}}">
         {{!-- Name and icon block; TODO: display chat card on click --}}
         <div class="name flexrow">
           <img class="icon" src="{{item.img}}" title="{{item.name}}"/>
@@ -34,8 +34,7 @@
         <div class="actions">{{#if item.system.actionsToUse}}{{item.system.actionsToUse}}{{/if}}</div>
 
         <div class="attack-bonus">
-          {{#if (eq item.system.weaponType "ranged")}}{{sum @root.system.aim item.system.attackBonus}}{{/if}}
-          {{#if (eq item.system.weaponType "melee")}}{{sum @root.system.melee item.system.attackBonus}}{{/if}}
+          {{ifThen item.attackBonus item.attackBonus ""}}
         </div>
 
         <div class="damage">

--- a/static/templates/sheets/unit-sheet.hbs
+++ b/static/templates/sheets/unit-sheet.hbs
@@ -18,15 +18,15 @@
 
             {{> "oh.unit-stats-defense"}}
 
-            {{> "oh.unit-weapons"}}
+            {{> "oh.unit-weapons" items.weapons}}
 
-            {{> "oh.unit-defenses"}}
+            {{> "oh.unit-defenses" items.defenses}}
 
-            {{> "oh.unit-items"}}
+            {{> "oh.unit-items" items.equipment}}
 
-            {{> "oh.unit-abilities"}}
+            {{> "oh.unit-abilities" items.abilities}}
 
-            {{> "oh.unit-skills"}}
+            {{> "oh.unit-skills" items.skills}}
         </div>
         <div>
             <p>


### PR DESCRIPTION
This implements Foundry's new Active Effect handling, allowing effects to remain embedded in their respective items but being transferred to the actor for data preparation.
To that end, each item sheet now has an `Effects` tab in which effects are listed (currently as one list – should separation into categories be desired, that can be implemented, too).

Active Effect config sheets have an additional `Effect Type` dropdown, allowing the AE to be marked as a `Stance` or a `Template` (names can still be changed).
`Template` type AEs do not get transferred to actors at all, excluding them from all application. Eventual application onto other actors is then possible by removing the type flag and thus making it an AE like any other.
Stances get special treatment when present on actors: their application gets suppressed if they are not the currently active stance, which can be configured in the actor sheet's sidebar.

Additionally, this includes basic Quench tests for some light regression testing. This automated testing can be expanded to be more in-depth once the API is stable, but preventing basic functionality from breaking is probably already desirable enough.

Also, this includes some light refactoring of styles, as well as moving some remaining parts of actor data preparation into the unit type model.