### PR TITLE
feat: add item use actions and on use effect handling

### DIFF
--- a/less/chat-messages.less
+++ b/less/chat-messages.less
@@ -65,18 +65,82 @@
         background: rgba(0, 0, 0, 0.1);
         padding: 0.2em;
 
-        header {
+        > header,
+        header h4 {
             font-weight: bold;
             margin-bottom: 0;
         }
     }
 
-    // Weapon reload
-    &.reload {
-        .reload-content {
-            margin-top: 0.5em;
-            margin-bottom: 0.5em;
+    // Coloring for warning signs
+    .warning {
+        font-weight: bold;
+        color: darkorange;
+    }
+
+    // Compact styling for lists
+    ul,
+    ol {
+        margin: 0;
+        padding: 0;
+    }
+
+    // Common styling for apply buttons
+    button.apply {
+        max-height: 32px;
+        max-width: 32px;
+    }
+
+    // Description blocks for various item uses
+    .description {
+        .description-content {
+            transition: max-height 0.75s ease-in-out;
+            max-height: 1.5rem;
+            overflow: hidden;
+            -webkit-mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0));
+            mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 1), rgba(0, 0, 0, 0));
         }
+        .description-content.expanded {
+            transition: max-height 0.75s ease-in-out;
+            max-height: 20rem;
+            overflow-y: auto;
+            -webkit-mask-image: none;
+            mask-image: none;
+        }
+    }
+
+    // On Use Effects
+    .effects {
+        grid-area: effects;
+        margin: 0;
+
+        > ul.effect-list {
+            margin: 0;
+        }
+
+        .effect {
+            .icon {
+                max-width: 32px;
+                max-height: 32px;
+                align-self: center;
+            }
+
+            &:not(:first-of-type) {
+                border-top: 1px groove rgba(0, 0, 0, 0.2);
+            }
+            &:nth-child(even) {
+                background: unset; // Remove background styling used in sheets
+            }
+        }
+    }
+    // ======================
+    // Specific action styles
+    // ======================
+
+    // Weapon reload
+    &.reload,
+    &.item-use {
+        gap: 0.3em;
     }
 
     // Weapon attack
@@ -84,10 +148,12 @@
         display: grid;
         grid-template-areas:
             "header header"
+            "description description"
             "attack-details ammo-range"
             "damage-details attack-costs"
             "properties properties"
-            "target-results target-results";
+            "target-results target-results"
+            "effects effects";
         grid-template-columns: 1fr 1fr;
         grid-template-rows: auto;
         gap: 0.3em;
@@ -106,14 +172,12 @@
             .number-of-attacks,
             .ap {
                 margin: 0.1em;
-
-                .ammo-empty {
-                    font-weight: bold;
-                    color: darkorange;
-                }
             }
         }
 
+        .description {
+            grid-area: description;
+        }
         .attack-details {
             grid-area: attack-details;
         }
@@ -136,14 +200,21 @@
             grid-area: properties;
         }
 
+        .effects {
+            grid-area: effects;
+        }
+
         .target-results {
             grid-area: target-results;
+            gap: 0.2em;
 
             .target-result {
                 // Add border between targets
-                margin: 0.3em 0 0.3em 0;
-                border-top: 1px groove rgba(0, 0, 0, 0.4);
                 gap: 0.2em;
+
+                &:not(:first-of-type) {
+                    border-top: 1px groove rgba(0, 0, 0, 0.2);
+                }
 
                 .target-icon {
                     max-width: 32px;
@@ -173,7 +244,6 @@
                 .apply-damage {
                     max-height: 32px;
                     max-width: 32px;
-                    align-self: end;
                 }
             }
             .target-damage {
@@ -181,11 +251,6 @@
                 .min-damage {
                     color: #aa0200;
                 }
-            }
-            .apply-damage {
-                max-height: 32px;
-                max-width: 32px;
-                align-self: end;
             }
         }
     }

--- a/module/actions/_module.mjs
+++ b/module/actions/_module.mjs
@@ -1,3 +1,4 @@
 export * from "./action.mjs";
 export * from "./reload.mjs";
 export * from "./weapon-attack.mjs";
+export * from "./item-use.mjs";

--- a/module/actions/item-use.mjs
+++ b/module/actions/item-use.mjs
@@ -1,0 +1,38 @@
+import { OUTERHEAVEN } from "../config.mjs";
+import { SYSTEM } from "../const.mjs";
+import { OuterHeavenAction } from "./action.mjs";
+
+export class ItemUseAction extends OuterHeavenAction {
+    static ACTION_TYPE = "itemUse";
+    static TEMPLATE = `${SYSTEM.TEMPLATE_PATH}/chat/item-use.hbs`;
+    static LABEL = "OH.ActionTypes.Use";
+
+    /** @override */
+    async _use(options) {
+        // Capacity
+        const { value: capacityValue, max: capacityMax } = this.item.system.capacity;
+        if (capacityValue <= 0) {
+            this._renderData.noCapacity = true;
+        }
+        this.itemUpdate["system.capacity.value"] = Math.clamped(capacityValue - 1, 0, capacityMax);
+
+        // Actor power
+        const powerCost = this.item.system.powerCost;
+        if (this.actor.system.power.isUsed && powerCost !== 0) {
+            const { value: powerValue, max: powerMax } = this.actor.system.power;
+            const power = (this._renderData.power = {
+                cost: powerCost,
+                value: powerValue,
+                max: powerMax,
+            });
+            if (powerCost > powerValue) {
+                power.warning = true;
+            }
+            this.actorUpdate["system.power.value"] = Math.clamped(powerValue - powerCost, 0, powerMax);
+        }
+
+        if (this.item.effects) this._addOnUseEffects();
+    }
+}
+
+OUTERHEAVEN.ACTIONS[ItemUseAction.ACTION_TYPE] = ItemUseAction;

--- a/module/actions/reload.mjs
+++ b/module/actions/reload.mjs
@@ -4,6 +4,7 @@ import { OuterHeavenAction } from "./action.mjs";
 export class ReloadAction extends OuterHeavenAction {
     static ACTION_TYPE = "reload";
     static TEMPLATE = "systems/outerheaven/templates/chat/reload.hbs";
+    static LABEL = "OH.ActionTypes.Reload";
 
     async _use(options) {
         this.itemUpdate["system.capacity.value"] = this.item.system.capacity.max;

--- a/module/actions/weapon-attack.mjs
+++ b/module/actions/weapon-attack.mjs
@@ -6,24 +6,16 @@ import { OuterHeavenAction } from "./action.mjs";
 export class AttackAction extends OuterHeavenAction {
     static ACTION_TYPE = "attack";
     static TEMPLATE = "systems/outerheaven/templates/chat/weapon-attack.hbs";
+    static LABEL = "OH.ActionTypes.Attack";
 
     /** @override */
-    static fromMessage(message) {
-        let actor, item;
-        const { itemId, results } = message.flags.outerheaven ?? {};
+    static fromData({ actor, item, token, rolls, ...flags } = {}) {
+        const action = super.fromData({ actor, item, token, ...flags });
 
-        if (itemId) {
-            item = fromUuidSync(itemId);
-            actor = item.actor;
-        }
-
-        const action = new this({ actor, item });
-
-        action.attackRoll = message.rolls[0];
-        action.damageRoll = message.rolls[1];
-        action.results = new foundry.utils.Collection(results.map((result) => [result._id, result]));
-        action.targets = results.map((result) => fromUuidSync(result._id));
-        action._messageFlags = message.flags;
+        action.attackRoll = rolls[0];
+        action.damageRoll = rolls[1];
+        action.results = new foundry.utils.Collection(flags.results.map((result) => [result._id, result]));
+        action.targets = flags.results.map((result) => fromUuidSync(result._id));
 
         return action;
     }
@@ -67,6 +59,8 @@ export class AttackAction extends OuterHeavenAction {
         if (this.item.system.capacity.value > 0) {
             this.itemUpdate["system.capacity.value"] = this.item.system.capacity.value - 1;
         }
+
+        if (this.item.effects) this._addOnUseEffects();
     }
 
     /**

--- a/module/applications/item-compendiums.mjs
+++ b/module/applications/item-compendiums.mjs
@@ -1,4 +1,4 @@
-import { SYSTEM_ID } from "../const.mjs";
+import { SYSTEM } from "../const.mjs";
 import { ItemCompendiumSettings } from "../data/settings.mjs";
 
 /**
@@ -6,7 +6,7 @@ import { ItemCompendiumSettings } from "../data/settings.mjs";
  */
 export class ItemCompendiumConfig extends FormApplication {
     constructor(object, options) {
-        super(object || game.settings.get(SYSTEM_ID, "itemCompendiums"), options);
+        super(object || game.settings.get(SYSTEM.ID, "itemCompendiums"), options);
     }
 
     /** @override */
@@ -14,10 +14,10 @@ export class ItemCompendiumConfig extends FormApplication {
         const options = super.defaultOptions;
         return {
             ...options,
-            id: `${SYSTEM_ID}-item-compendiums`,
+            id: `${SYSTEM.ID}-item-compendiums`,
             title: game.i18n.localize("OH.Settings.ItemCompendiums.Name"),
-            classes: [...options.classes, SYSTEM_ID, "item-compendiums"],
-            template: `systems/${SYSTEM_ID}/templates/applications/item-compendiums.hbs`,
+            classes: [...options.classes, SYSTEM.ID, "item-compendiums"],
+            template: `systems/${SYSTEM.ID}/templates/applications/item-compendiums.hbs`,
             width: 600,
             height: "auto",
             closeOnSubmit: true,
@@ -48,7 +48,7 @@ export class ItemCompendiumConfig extends FormApplication {
 
     /** @override */
     _updateObject(_event, formData) {
-        return game.settings.set(SYSTEM_ID, "itemCompendiums", formData);
+        return game.settings.set(SYSTEM.ID, "itemCompendiums", formData);
     }
 
     /** @override */

--- a/module/applications/teams-config.mjs
+++ b/module/applications/teams-config.mjs
@@ -1,4 +1,4 @@
-import { SYSTEM_ID } from "../const.mjs";
+import { SYSTEM } from "../const.mjs";
 import { Team } from "../data/combat.mjs";
 import { generateId } from "../utils.mjs";
 
@@ -15,7 +15,7 @@ export class TeamsConfig extends FormApplication {
         /** @type {object[]} */
         const rawTeams = combat
             ? combat.system.toObject().teams
-            : game.settings.get(SYSTEM_ID, "defaultTeams").map((team) => team.toObject());
+            : game.settings.get(SYSTEM.ID, "defaultTeams").map((team) => team.toObject());
         const teams = rawTeams.map((team) => new Team(team, { parent: combat }));
         super(teams, options);
         this.combat = combat;
@@ -26,9 +26,9 @@ export class TeamsConfig extends FormApplication {
         const options = super.defaultOptions;
         return {
             ...options,
-            id: `${SYSTEM_ID}-teams-config`,
-            classes: [...options.classes, SYSTEM_ID, "teams-config"],
-            template: `systems/${SYSTEM_ID}/templates/applications/teams-config.hbs`,
+            id: `${SYSTEM.ID}-teams-config`,
+            classes: [...options.classes, SYSTEM.ID, "teams-config"],
+            template: `systems/${SYSTEM.ID}/templates/applications/teams-config.hbs`,
             tabs: [{ navSelector: ".tabs", contentSelector: ".content" }],
             dragDrop: [{ dragSelector: ".team", dropSelector: ".tabs" }],
             width: 600,
@@ -133,10 +133,10 @@ export class TeamsConfig extends FormApplication {
         const teams = this.object.map((team) => team.toObject());
 
         if (this.combat) {
-            await this.combat.update({ [`flags.${SYSTEM_ID}.teams`]: teams });
+            await this.combat.update({ [`flags.${SYSTEM.ID}.teams`]: teams });
             this.combat.render();
         } else {
-            await game.settings.set(SYSTEM_ID, "defaultTeams", teams);
+            await game.settings.set(SYSTEM.ID, "defaultTeams", teams);
         }
 
         this.close();

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -41,7 +41,7 @@ OUTERHEAVEN.armorTypes = {
 
 OUTERHEAVEN.effectTypes = {
     stance: "OH.EffectTypes.Stance",
-    template: "OH.EffectTypes.Template",
+    onUse: "OH.EffectTypes.OnUse",
 };
 
 OUTERHEAVEN.ACTIONS = {};

--- a/module/const.mjs
+++ b/module/const.mjs
@@ -1,4 +1,11 @@
 /**
- * The ID of the system/package.
+ * Constants used throughout the system referring to its ID.
  */
-export const SYSTEM_ID = "outerheaven";
+export const SYSTEM = /** @type {const} */ ({
+    /** The package ID */
+    ID: "outerheaven",
+    /** The package name */
+    NAME: "Outer Heaven",
+    /** The base path for the package's template files */
+    TEMPLATE_PATH: "systems/outerheaven/templates",
+});

--- a/module/data/combat.mjs
+++ b/module/data/combat.mjs
@@ -1,4 +1,4 @@
-import { SYSTEM_ID } from "../const.mjs";
+import { SYSTEM } from "../const.mjs";
 import { CollectionField } from "./fields/collection.mjs";
 
 /**
@@ -57,7 +57,7 @@ export class Team extends foundry.abstract.DataModel {
      * @type {Combatant[]}
      */
     get combatants() {
-        return this.combat?.combatants.filter((c) => c.flags[SYSTEM_ID]?.team === this.id) ?? [];
+        return this.combat?.combatants.filter((c) => c.flags[SYSTEM.ID]?.team === this.id) ?? [];
     }
 
     /**

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -44,8 +44,8 @@ export class OHActiveEffect extends ActiveEffect {
 
     /** @override */
     prepareDerivedData() {
-        // Never transfer "template" type effects that are meant to be applied to _other_ actors
-        if (this.system.type === "template") this.transfer = false;
+        // Never transfer "onUse" type effects that are meant to be applied to _other_ actors
+        if (this.system.type === "onUse") this.transfer = false;
     }
 
     /**

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -1,5 +1,5 @@
 import { TeamsConfig } from "../applications/teams-config.mjs";
-import { SYSTEM_ID } from "../const.mjs";
+import { SYSTEM } from "../const.mjs";
 import { CombatData, Team } from "../data/combat.mjs";
 import { generateId } from "../utils.mjs";
 
@@ -23,9 +23,9 @@ export class OHCombat extends Combat {
         await super._preCreate(data, options, user);
 
         // Add default teams if the combat is not created with any
-        if (!hasProperty(data, `flags.${SYSTEM_ID}.teams`)) {
+        if (!hasProperty(data, `flags.${SYSTEM.ID}.teams`)) {
             /** @type {object[]} */
-            const teamsData = game.settings.get(SYSTEM_ID, "defaultTeams").map((team) => team.toObject());
+            const teamsData = game.settings.get(SYSTEM.ID, "defaultTeams").map((team) => team.toObject());
             const teams = teamsData.reduce((teams, team, index) => {
                 teams.push({
                     ...team,
@@ -34,7 +34,7 @@ export class OHCombat extends Combat {
                 });
                 return teams;
             }, []);
-            this.updateSource({ [`flags.${SYSTEM_ID}.teams`]: teams });
+            this.updateSource({ [`flags.${SYSTEM.ID}.teams`]: teams });
         }
     }
 
@@ -42,12 +42,12 @@ export class OHCombat extends Combat {
     async _preUpdate(data, options, user) {
         await super._preUpdate(data, options, user);
 
-        if (foundry.utils.hasProperty(data, `flags.${SYSTEM_ID}`)) {
+        if (foundry.utils.hasProperty(data, `flags.${SYSTEM.ID}`)) {
             // Clean and validate `flags.outerheaven` before updating
             foundry.utils.setProperty(
                 data,
-                `flags.${SYSTEM_ID}`,
-                this.system.updateSource(data.flags[SYSTEM_ID], { dryRun: true }),
+                `flags.${SYSTEM.ID}`,
+                this.system.updateSource(data.flags[SYSTEM.ID], { dryRun: true }),
             );
         }
     }
@@ -56,7 +56,7 @@ export class OHCombat extends Combat {
     prepareBaseData() {
         super.prepareBaseData();
         // Initialize a pseudo-system space to enable DataModel validation
-        this.system = new CombatData(this.flags[SYSTEM_ID] ?? {}, { parent: this });
+        this.system = new CombatData(this.flags[SYSTEM.ID] ?? {}, { parent: this });
     }
 
     /** @override */
@@ -65,7 +65,7 @@ export class OHCombat extends Combat {
         super._onUpdate(data, options, userId);
 
         // Core only cares about combatants, but the system attaches the setup to teams instead
-        if (foundry.utils.hasProperty(data, `flags.${SYSTEM_ID}.teams`)) {
+        if (foundry.utils.hasProperty(data, `flags.${SYSTEM.ID}.teams`)) {
             const team = this.teamTurns.find((t) => t.sort === this.turn)?.id;
             this.setupTurns();
             const adjustedTurn = team ? this.system.teams.get(team).sort : undefined;
@@ -162,7 +162,7 @@ export class OHCombat extends Combat {
      */
     async resetDone(ids = [], options = { render: false, turnEvents: false }) {
         const combatants = ids.length ? this.combatants.filter((c) => ids.includes(c.id)) : this.combatants;
-        const updates = combatants.map((c) => ({ _id: c.id, [`flags.${SYSTEM_ID}.done`]: false }));
+        const updates = combatants.map((c) => ({ _id: c.id, [`flags.${SYSTEM.ID}.done`]: false }));
         return this.updateEmbeddedDocuments("Combatant", updates, options);
     }
 

--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -1,4 +1,4 @@
-import { SYSTEM_ID } from "../const.mjs";
+import { SYSTEM } from "../const.mjs";
 import { CombatantData } from "../data/combatant.mjs";
 
 export class OHCombatant extends Combatant {
@@ -6,11 +6,11 @@ export class OHCombatant extends Combatant {
     async _preUpdate(data, options, user) {
         await super._preUpdate(data, options, user);
 
-        if (foundry.utils.hasProperty(data, `flags.${SYSTEM_ID}`)) {
+        if (foundry.utils.hasProperty(data, `flags.${SYSTEM.ID}`)) {
             foundry.utils.setProperty(
                 data,
-                `flags.${SYSTEM_ID}`,
-                this.system.updateSource(data.flags[SYSTEM_ID], { dryRun: true }),
+                `flags.${SYSTEM.ID}`,
+                this.system.updateSource(data.flags[SYSTEM.ID], { dryRun: true }),
             );
         }
     }
@@ -18,7 +18,7 @@ export class OHCombatant extends Combatant {
     /** @override */
     prepareBaseData() {
         super.prepareBaseData();
-        this.system = new CombatantData(this.flags[SYSTEM_ID] ?? {}, { parent: this });
+        this.system = new CombatantData(this.flags[SYSTEM.ID] ?? {}, { parent: this });
     }
 
     /** @override */
@@ -35,6 +35,6 @@ export class OHCombatant extends Combatant {
 
     async toggleDone(state = null) {
         const targetState = state !== null ? state : !this.system.done;
-        return this.update({ [`flags.${SYSTEM_ID}.done`]: targetState });
+        return this.update({ [`flags.${SYSTEM.ID}.done`]: targetState });
     }
 }

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -1,6 +1,6 @@
 import { ItemCompendiumConfig } from "./applications/item-compendiums.mjs";
 import { TeamsConfig } from "./applications/teams-config.mjs";
-import { SYSTEM_ID } from "./const.mjs";
+import { SYSTEM } from "./const.mjs";
 import { Team } from "./data/combat.mjs";
 import { ItemCompendiumSettings } from "./data/settings.mjs";
 
@@ -11,7 +11,7 @@ import { ItemCompendiumSettings } from "./data/settings.mjs";
  */
 export function registerSettings() {
     // Damage dice explosion
-    game.settings.register(SYSTEM_ID, "criticals", {
+    game.settings.register(SYSTEM.ID, "criticals", {
         name: "OH.Settings.Criticals.Name",
         hint: "OH.Settings.Criticals.Hint",
         scope: "world",
@@ -26,13 +26,13 @@ export function registerSettings() {
     });
 
     // Compendium buttons
-    game.settings.register(SYSTEM_ID, "itemCompendiums", {
+    game.settings.register(SYSTEM.ID, "itemCompendiums", {
         type: ItemCompendiumSettings,
         scope: "world",
         config: false,
         default: new ItemCompendiumSettings().toObject(),
     });
-    game.settings.registerMenu(SYSTEM_ID, "itemCompendiums", {
+    game.settings.registerMenu(SYSTEM.ID, "itemCompendiums", {
         name: "OH.Settings.ItemCompendiums.Name",
         label: "OH.Settings.ItemCompendiums.Label",
         hint: "OH.Settings.ItemCompendiums.Hint",
@@ -42,18 +42,28 @@ export function registerSettings() {
     });
 
     // Default teams
-    game.settings.register(SYSTEM_ID, "defaultTeams", {
+    game.settings.register(SYSTEM.ID, "defaultTeams", {
         scope: "world",
         config: false,
         type: (value) => value.map((team) => new Team(team)),
         default: [],
     });
-    game.settings.registerMenu(SYSTEM_ID, "teamsConfig", {
+    game.settings.registerMenu(SYSTEM.ID, "teamsConfig", {
         name: "OH.Settings.TeamsConfig.Name",
         label: "OH.Settings.TeamsConfig.Label",
         hint: "OH.Settings.TeamsConfig.Hint",
         icon: "fas fa-flag",
         type: TeamsConfig,
         restricted: true,
+    });
+
+    // Item descriptions in chat
+    game.settings.register(SYSTEM.ID, "expandDescriptions", {
+        name: "OH.Settings.ExpandDescriptions.Name",
+        hint: "OH.Settings.ExpandDescriptions.Hint",
+        scope: "client",
+        config: true,
+        type: Boolean,
+        default: false,
     });
 }

--- a/module/sheets/combat-tracker.mjs
+++ b/module/sheets/combat-tracker.mjs
@@ -1,5 +1,5 @@
 import { TeamsConfig } from "../applications/teams-config.mjs";
-import { SYSTEM_ID } from "../const.mjs";
+import { SYSTEM } from "../const.mjs";
 
 export class OHCombatTracker extends CombatTracker {
     /** @override */
@@ -11,7 +11,7 @@ export class OHCombatTracker extends CombatTracker {
 
     /** @override */
     get template() {
-        return `systems/${SYSTEM_ID}/templates/sheets/combat-tracker.hbs`;
+        return `systems/${SYSTEM.ID}/templates/sheets/combat-tracker.hbs`;
     }
 
     /** @override */
@@ -114,9 +114,9 @@ export class OHCombatTracker extends CombatTracker {
                 const teamId = teamLi?.dataset.teamId;
                 const team = combat.system.teams.get(teamId);
                 if (team) {
-                    combatant.update({ [`flags.${SYSTEM_ID}.team`]: teamId });
+                    combatant.update({ [`flags.${SYSTEM.ID}.team`]: teamId });
                 } else {
-                    combatant.update({ [`flags.${SYSTEM_ID}.team`]: "" });
+                    combatant.update({ [`flags.${SYSTEM.ID}.team`]: "" });
                 }
                 break;
             }
@@ -146,7 +146,7 @@ export class OHCombatTracker extends CombatTracker {
         sorted.splice(targetIndex, 0, source);
 
         const sortedTeamData = sorted.map((team, index) => ({ ...team.toObject(), sort: index + 1 }));
-        return this.viewed.update({ [`flags.${SYSTEM_ID}.teams`]: sortedTeamData });
+        return this.viewed.update({ [`flags.${SYSTEM.ID}.teams`]: sortedTeamData });
     }
 
     /** @override */

--- a/module/tests/active-effects.spec.mjs
+++ b/module/tests/active-effects.spec.mjs
@@ -1,4 +1,4 @@
-import { SYSTEM_ID } from "../const.mjs";
+import { SYSTEM } from "../const.mjs";
 import { createActor, createEffects, createItems, updateSource } from "./utils.mjs";
 
 /**
@@ -6,7 +6,7 @@ import { createActor, createEffects, createItems, updateSource } from "./utils.m
  */
 export function registerActiveEffectTests(quench) {
     quench.registerBatch(
-        `${SYSTEM_ID}.active-effects.basic`,
+        `${SYSTEM.ID}.active-effects.basic`,
         (context) => {
             const { describe, it, assert, expect, should, before, after } = context;
 
@@ -25,19 +25,19 @@ export function registerActiveEffectTests(quench) {
                     expect(ae.system.type).to.equal("stance");
                 });
 
-                it("should accept template type", function () {
+                it("should accept onUse type", function () {
                     const ae = new ActiveEffect.implementation({
                         name: "Test Effect",
-                        flags: { outerheaven: { type: "template" } },
+                        flags: { outerheaven: { type: "onUse" } },
                     });
                     expect(ae).to.be.an.instanceof(ActiveEffect);
-                    expect(ae.system.type).to.equal("template");
+                    expect(ae.system.type).to.equal("onUse");
                 });
 
-                it("should not transfer template type effects", function () {
+                it("should not transfer onUse type effects", function () {
                     const actor = createActor();
                     const [item] = createItems([{ name: "AE Test Armor" }], { parent: actor });
-                    const [effect] = createEffects([{ name: "AE Test Effect", system: { type: "template" } }], {
+                    const [effect] = createEffects([{ name: "AE Test Effect", system: { type: "onUse" } }], {
                         parent: item,
                     });
 

--- a/module/tests/actor-basic.spec.mjs
+++ b/module/tests/actor-basic.spec.mjs
@@ -1,4 +1,4 @@
-import { SYSTEM_ID } from "../const.mjs";
+import { SYSTEM } from "../const.mjs";
 import { createActor, createItems } from "./utils.mjs";
 
 /**
@@ -6,7 +6,7 @@ import { createActor, createItems } from "./utils.mjs";
  */
 export function registerBasicActorTests(quench) {
     quench.registerBatch(
-        `${SYSTEM_ID}.actor.basic`,
+        `${SYSTEM.ID}.actor.basic`,
         (context) => {
             const { describe, it, assert, expect, should, before, after } = context;
 

--- a/module/tests/weapon-attack.spec.mjs
+++ b/module/tests/weapon-attack.spec.mjs
@@ -1,10 +1,10 @@
-import { SYSTEM_ID } from "../const.mjs";
+import { SYSTEM } from "../const.mjs";
 import { DamageRoll } from "../dice/damage-roll.mjs";
 
 /** @param {import("@ethaks/fvtt-quench/lib").Quench} quench */
 export function registerWeaponAttackTest(quench) {
     quench.registerBatch(
-        `${SYSTEM_ID}.weapon-attack`,
+        `${SYSTEM.ID}.weapon-attack`,
         (context) => {
             const { describe, it, assert, expect, should, before, after } = context;
 

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -1,3 +1,5 @@
+import { SYSTEM } from "./const.mjs";
+
 /**
  * Request all template partials from the server and cache them for later use.
  * Partials are available by their paths as well as through `oh.${partialName}`.
@@ -6,22 +8,23 @@
  */
 export async function preloadHandlebarsTemplates() {
     const partials = [
-        "systems/outerheaven/templates/sheets/parts/melee-block.hbs",
-        "systems/outerheaven/templates/sheets/parts/ranged-block.hbs",
-        "systems/outerheaven/templates/sheets/parts/unit-abilities.hbs",
-        "systems/outerheaven/templates/sheets/parts/unit-defenses.hbs",
-        "systems/outerheaven/templates/sheets/parts/unit-items.hbs",
-        "systems/outerheaven/templates/sheets/parts/unit-skills.hbs",
-        "systems/outerheaven/templates/sheets/parts/unit-stats-sidebar.hbs",
-        "systems/outerheaven/templates/sheets/parts/unit-stats-defense.hbs",
-        "systems/outerheaven/templates/sheets/parts/unit-weapons.hbs",
-        "systems/outerheaven/templates/sheets/parts/item-effects.hbs",
-        "systems/outerheaven/templates/chat/item-display.hbs",
-        "systems/outerheaven/templates/chat/defense-display.hbs",
-        "systems/outerheaven/templates/chat/defense-stats-display.hbs",
-        "systems/outerheaven/templates/chat/weapon-display.hbs",
-        "systems/outerheaven/templates/chat/weapon-attack.hbs",
-    ];
+        "sheets/parts/melee-block.hbs",
+        "sheets/parts/ranged-block.hbs",
+        "sheets/parts/unit-abilities.hbs",
+        "sheets/parts/unit-defenses.hbs",
+        "sheets/parts/unit-items.hbs",
+        "sheets/parts/unit-skills.hbs",
+        "sheets/parts/unit-stats-sidebar.hbs",
+        "sheets/parts/unit-stats-defense.hbs",
+        "sheets/parts/unit-weapons.hbs",
+        "sheets/parts/item-effects.hbs",
+        "chat/item-display.hbs",
+        "chat/defense-display.hbs",
+        "chat/defense-stats-display.hbs",
+        "chat/weapon-display.hbs",
+        "chat/weapon-attack.hbs",
+        "chat/parts/on-use-effects.hbs",
+    ].map((path) => `${SYSTEM.TEMPLATE_PATH}/${path}`);
 
     const paths = {};
     for (const path of partials) {

--- a/outerheaven.mjs
+++ b/outerheaven.mjs
@@ -12,7 +12,7 @@ import * as documents from "./module/documents/_module.mjs";
 import * as sheets from "./module/sheets/_module.mjs";
 import * as utils from "./module/utils.mjs";
 import { registerSettings } from "./module/settings.mjs";
-import { SYSTEM_ID } from "./module/const.mjs";
+import { SYSTEM } from "./module/const.mjs";
 
 // API
 export { actions, OUTERHEAVEN as config, dataModels, dice, documents, sheets };
@@ -61,7 +61,7 @@ Hooks.once("init", function () {
     // Active Effects
     CONFIG.ActiveEffect.legacyTransferral = false;
     CONFIG.ActiveEffect.documentClass = documents.OHActiveEffect;
-    DocumentSheetConfig.registerSheet(ActiveEffect, SYSTEM_ID, sheets.OHActiveEffectConfig, { makeDefault: true });
+    DocumentSheetConfig.registerSheet(ActiveEffect, SYSTEM.ID, sheets.OHActiveEffectConfig, { makeDefault: true });
 
     // Combat
     CONFIG.Combat.documentClass = documents.OHCombat;
@@ -101,10 +101,37 @@ Hooks.once("ready", function () {
     console.log("Outer Heaven | Activated Macro Drag&Drop");
 });
 
-Hooks.on("renderChatLog", (app, html, data) => {
-    html.on("click", "button.apply-damage", (event) => {
+Hooks.on("renderChatLog", (_app, html, _data) => {
+    html.on("click", ".outerheaven button.apply", (event) => {
         const message = game.messages.get(event.currentTarget.closest(".message").dataset.messageId);
-        const targetId = event.currentTarget.dataset.targetId;
-        message.action.applyTargetDamage(targetId);
+        /** @type {actions.OuterHeavenAction} */
+        const messageAction = message.action;
+        const applyAction = event.currentTarget.dataset.action;
+
+        switch (applyAction) {
+            case "damage": {
+                const targetId = event.currentTarget.dataset.targetId;
+                return messageAction.applyTargetDamage(targetId);
+            }
+            case "effect": {
+                const effectId = event.currentTarget.dataset.effectId;
+                return messageAction.applyEffect(effectId);
+            }
+        }
     });
+
+    html.on("click", ".outerheaven .description", (event) => {
+        // Toggle expanded state
+        event.currentTarget.closest(".description").querySelector(".description-content").classList.toggle("expanded");
+    });
+});
+
+Hooks.on("renderChatMessage", (_message, html, _data) => {
+    const description = html[0].querySelector(".outerheaven .description");
+    if (description) {
+        const expandDescriptions = game.settings.get(SYSTEM.ID, "expandDescriptions");
+        if (expandDescriptions) {
+            description.querySelector(".description-content").classList.add("expanded");
+        }
+    }
 });

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -39,6 +39,10 @@
                 "Add": "Add Team",
                 "Remove": "Remove Team",
                 "NewTeam": "New Team"
+            },
+            "ExpandDescriptions": {
+                "Name": "Expand Descriptions in Chat",
+                "Hint": "If checked, item descriptions appear expanded by default in chat messages."
             }
         },
 
@@ -81,12 +85,18 @@
         "EffectType": "Effect Type",
         "EffectTypes": {
             "Stance": "Stance",
-            "Template": "Template",
+            "OnUse": "On Use",
             "Hint": "Types the system attaches special behavior to."
         },
 
         "Notifications": {
             "ItemMacroOnlyOwned": "Item macros can only be created for owned items."
+        },
+
+        "ActionTypes": {
+            "Use": "Use",
+            "Attack": "Attack",
+            "Reload": "Reload"
         },
 
         "Create": "Create",
@@ -105,12 +115,15 @@
         "Shots": "Shots",
         "Strikes": "Strikes",
         "Ammo": "Ammo",
-        "NoAmmo": "No Ammo",
+        "NoAmmo": "Not enough ammo",
         "Uses": "Uses",
+        "NoUses": "Not enough uses",
         "Actions": "Actions",
         "ActionsToFire": "Actions to fire",
         "Max": "Max",
+        "Power": "Power",
         "PowerCost": "Power Cost",
+        "NoPower": "Not enough power",
         "Attack": "Attack",
         "Reload": "Reload",
         "WeaponReloaded": "Weapon has been reloaded.",
@@ -121,6 +134,7 @@
         "Damage": "Damage",
         "Benefits": "Benefits",
         "Properties": "Properties",
+        "Description": "Description",
 
         "Defenses": "Defenses",
         "Armor": "Armor",

--- a/static/templates/chat/item-use.hbs
+++ b/static/templates/chat/item-use.hbs
@@ -1,0 +1,38 @@
+<div class="outerheaven item-use flexcol">
+    <header class="card-header flexrow">
+        <img src="{{item.img}}" title="{{item.name}}" height="32" width="32"/>
+        <h3 class="item-name">{{item.name}}</h3>
+    </header>
+
+    {{! Description}}
+    {{#if description}}
+        <div class="description content-box">
+            <header class="description-header">{{localize "OH.Description"}}</header>
+            <div class="description-content">{{{description}}}</div>
+        </div>
+    {{/if}}
+
+    {{! Usage Details}}
+    <div class="content-box flexcol">
+        <div class="capacity">{{localize "OH.Uses"}} {{item.system.capacity.value}} / {{item.system.capacity.max}}
+            {{#if noCapacity}}
+                <i class="fas fa-exclamation-triangle warning" data-tooltip="{{localize "OH.NoUses"}}"></i>
+            {{/if}}
+        </div>
+
+        {{#if power}}
+            <div class="power">
+                <span class="actor-power">{{localize "OH.Power"}} {{power.value}} / {{power.max}}</span>
+                {{#if power.warning}}
+                    <i class="fas fa-exclamation-triangle warning" data-tooltip="{{localize "OH.NoPower"}}"></i>
+                {{/if}}
+            </div>
+        {{/if}}
+
+    </div>
+
+    {{! On Use Effects}}
+    {{#if effects}}
+        {{~> "oh.on-use-effects"}}
+    {{/if}}
+</div>

--- a/static/templates/chat/parts/on-use-effects.hbs
+++ b/static/templates/chat/parts/on-use-effects.hbs
@@ -1,0 +1,14 @@
+<div class="content-box effects">
+    <header class="effects-header"><h4>{{localize "OH.Effects"}}</h4></header>
+    <ul class="effect-list">
+        {{#each effects as |effect| }}
+            <li class="flexrow effect" data-effect-id="{{effect.id}}">
+                <img src="{{effect.img}}" class="icon" title="{{effect.name}}">
+                <span class="name">{{effect.name}}</span>
+                <button class="apply apply-effect" data-tooltip="OH.ApplyEffect" data-action="effect" data-effect-id="{{effect.id}}">
+                    <i class="fas fa-check"></i>
+                </button>
+            </li>
+        {{/each}}
+    </ul>
+</div>

--- a/static/templates/chat/reload.hbs
+++ b/static/templates/chat/reload.hbs
@@ -1,13 +1,15 @@
-<div class="outerheaven reload">
+<div class="outerheaven reload flexcol">
   <header class="card-header flexrow">
     <img src="{{item.img}}" title="{{item.name}}" height="32" width="32"/>
     <h3 class="item-name">{{item.name}}</h3>
   </header>
+
   <div class="reload-content content-box flexcol">
     <span class="reloaded-text">{{localize "OH.WeaponReloaded"}}</span>
     <span class="action-cost">{{localize "OH.ActionsToFire"}}: {{item.system.actionsToUse}}</span>
     <span class="ammo">{{localize "OH.Ammo"}} {{item.system.capacity.value}} / {{item.system.capacity.max}}</span>
   </div>
+
   <div class="properties content-box">
     <header class="properties-header">{{localize "OH.Properties"}}</header>
     <span class="properties-content">{{item.system.properties}}</span>

--- a/static/templates/chat/weapon-attack.hbs
+++ b/static/templates/chat/weapon-attack.hbs
@@ -4,114 +4,129 @@
     <h3 class="item-name">{{item.name}}</h3>
   </header>
 
+    {{! Description}}
+    {{#if description}}
+        <div class="description content-box">
+            <header class="description-header">{{localize "OH.Description"}}</header>
+            <div class="description-content">{{{description}}}</div>
+        </div>
+    {{/if}}
+
   {{!-- Attack Roll --}}
   <div class="attack-details content-box">
     <div class="dice-roll">
       <div class="dice-result">
         <div class="dice-flavor">vs {{vsDefense}}</div>
-        <h4 class="dice-total" data-tooltip="{{atkRoll.formula}}">{{atkRoll.total}}</h4>
-        {{{atkRoll.tooltip}}}
-      </div>
-    </div>
-  </div>
-
-  {{!-- Ammo and Range info --}}
-  <div class="ammo-range content-box flexcol">
-    <div class="ammo">
-      {{#if (or item.system.capacity.value item.system.capacity.max noAmmo)}}
-        {{#if (eq item.system.weaponType "ranged")}}
-          {{localize "OH.Ammo"}}
-        {{else}}
-          {{localize "OH.Uses"}}
-        {{/if}}
-        {{item.system.capacity.value}}{{#if item.system.capacity.max}} / {{item.system.capacity.max}}{{/if}}
-        {{#if noAmmo}}
-          <i class="fas fa-exclamation-triangle ammo-empty" data-tooltip="OH.NoAmmo"></i>
-        {{/if}}
-      {{/if}}
-    </div>
-      {{#if (eq item.system.weaponType "ranged")}}
-        <span class="range">{{localize "OH.Range"}} {{item.system.range}}</span>
-      {{/if}}
-  </div>
-
-  {{!-- Damage Roll --}}
-  <div class="damage-details content-box">
-    <div class="dice-roll">
-      <div class="dice-result">
-        <div class="dice-flavor">{{lookup config.damageTypes item.system.damageType}}</div>
-        <h4 class="dice-total" data-tooltip="{{dmgRoll.formula}}">{{dmgRoll.total}}</h4>
-        {{{dmgRoll.tooltip}}}
-      </div>
-    </div>
-  </div>
-
-  {{!-- Attack Cost and Apply Damage button --}}
-  <div class="attack-costs content-box flexrow">
-    <div class="details flexcol">
-      <span class="number-of-attacks">{{item.system.numberOfAttacks}} 
-        {{#if (eq item.system.weaponType "ranged")}}{{localize "OH.Shots"}}{{else}}{{localize "OH.Strikes"}}{{/if}}
-      </span>
-      <span class="ap">{{localize "OH.TotalAP"}} {{totalAp}}</span>
-    </div>
-    <button class="apply-damage"> <i class="fas fa-check"></i> </button>
-  </div>
-
-  {{!-- Properties --}}
-  <div class="properties content-box">
-    <header class="properties-header">{{localize "OH.Properties"}}</header>
-    <span class="properties-content">{{item.system.properties}}</span>
-  </div>
-
-  {{!-- Targets --}}
-  {{#if results}}
-    <div class="target-results content-box flexcol">
-      <header>{{localize "OH.Targets"}}</h4>
-      {{#each results as |result index|}}
-        <div class="target-result flexrow">
-          {{!-- Target icon --}}
-          <img class="target-icon" src="{{result.img}}" data-edit="img" title="{{result.name}}" />
-          {{!-- Target info --}}
-          <div class="flexcol">
-            <div class="flexrow">
-              <span class="target-name">{{result.name}}</span>
-              {{#if result.distance}}
-                <span class="target-range">{{localize "OH.Range"}} {{result.distance}}</span>
-              {{/if}}
+                <h4 class="dice-total" data-tooltip="{{atkRoll.formula}}">{{atkRoll.total}}</h4>
+                {{{atkRoll.tooltip}}}
             </div>
-
-          <div class="target-rolls flexrow">
-            {{!-- Effective attack roll --}}
-            <div class="dice-roll target-attack">
-              <div class="dice-result">
-                <div class="dice-flavor">{{@root.vsDefense}}</div>
-                <h4 class="dice-total {{#if result.isHit}}hit{{else}}miss{{/if}}" data-tooltip="{{result.defense.formula}}">
-                  {{result.defense.total}}
-                </h4>
-              </div>
-            </div>
-
-            {{!-- Effective damage roll --}}
-            <div class="dice-roll target-damage">
-              <div class="dice-result">
-                <div class="dice-flavor">{{lookup @root.config.damageTypes @root.item.system.damageType}}</div>
-                <h4 class="dice-total {{#if result.damage.isMinimum}}min-damage{{/if}}" data-tooltip="{{result.damage.formula}}">
-                  {{result.damage.total}}
-                </h4>
-                {{{@root.dmgRoll.tooltip}}}
-              </div>
-            </div>
-
-            {{!-- Apply damage button --}}
-            <button class="apply-damage" data-target-id="{{result._id}}"> 
-              {{#if result.isHit}} <i class="fas fa-check"></i> {{else}} <i class="fas fa-times"></i> {{/if}}
-            </button>
-            </div>
-          </div>
-
-
         </div>
-      {{/each}}
     </div>
-  {{/if}}
+
+    {{!-- Ammo and Range info --}}
+    <div class="ammo-range content-box flexcol">
+        <div class="ammo">
+            {{#if (or item.system.capacity.value item.system.capacity.max noAmmo)}}
+                {{#if (eq item.system.weaponType "ranged")}}
+                    {{localize "OH.Ammo"}}
+                {{else}}
+                    {{localize "OH.Uses"}}
+                {{/if}}
+                {{item.system.capacity.value}}{{#if item.system.capacity.max}} / {{item.system.capacity.max}}{{/if}}
+                {{#if noAmmo}}
+                    <i class="fas fa-exclamation-triangle warning" data-tooltip="OH.NoAmmo"></i>
+                {{/if}}
+            {{/if}}
+        </div>
+        {{#if (eq item.system.weaponType "ranged")}}
+            <span class="range">{{localize "OH.Range"}} {{item.system.range}}</span>
+        {{/if}}
+    </div>
+
+    {{!-- Damage Roll --}}
+    <div class="damage-details content-box">
+        <div class="dice-roll">
+            <div class="dice-result">
+                <div class="dice-flavor">{{lookup config.damageTypes item.system.damageType}}</div>
+                <h4 class="dice-total" data-tooltip="{{dmgRoll.formula}}">{{dmgRoll.total}}</h4>
+                {{{dmgRoll.tooltip}}}
+            </div>
+        </div>
+    </div>
+
+    {{!-- Attack Cost and Apply Damage button --}}
+    <div class="attack-costs content-box flexrow">
+        <div class="details flexcol">
+            <span class="number-of-attacks">{{item.system.numberOfAttacks}} 
+                {{#if (eq item.system.weaponType "ranged")}}{{localize "OH.Shots"}}{{else}}{{localize "OH.Strikes"}}{{/if}}
+            </span>
+            <span class="ap">{{localize "OH.TotalAP"}} {{totalAp}}</span>
+        </div>
+        <button class="apply apply-damage" data-action="damage" data-tooltip="OH.ApplyDamage"> <i class="fas fa-check"></i> </button>
+    </div>
+
+    {{!-- Properties --}}
+    <div class="properties content-box">
+        <header class="properties-header">{{localize "OH.Properties"}}</header>
+        <span class="properties-content">{{item.system.properties}}</span>
+    </div>
+
+    {{!-- Targets --}}
+    {{#if results}}
+        <div class="target-results content-box flexcol">
+            <header>
+                <h4>{{localize "OH.Targets"}}</h4>
+            </header>
+            {{#each results as |result index|}}
+                <div class="target-result flexrow">
+                    {{!-- Target icon --}}
+                    <img class="target-icon" src="{{result.img}}" title="{{result.name}}" />
+                    {{!-- Target info --}}
+                    <div class="flexcol">
+                        <div class="flexrow">
+                            <span class="target-name">{{result.name}}</span>
+                            {{#if result.distance}}
+                                <span class="target-range">{{localize "OH.Range"}} {{result.distance}}</span>
+                            {{/if}}
+                        </div>
+
+                        <div class="target-rolls flexrow">
+                            {{!-- Effective attack roll --}}
+                            <div class="dice-roll target-attack">
+                                <div class="dice-result">
+                                    <div class="dice-flavor">{{@root.vsDefense}}</div>
+                                    <h4 class="dice-total {{#if result.isHit}}hit{{else}}miss{{/if}}" data-tooltip="{{result.defense.formula}}">
+                                        {{result.defense.total}}
+                                    </h4>
+                                </div>
+                            </div>
+
+                            {{!-- Effective damage roll --}}
+                            <div class="dice-roll target-damage">
+                                <div class="dice-result">
+                                    <div class="dice-flavor">{{lookup @root.config.damageTypes @root.item.system.damageType}}</div>
+                                    <h4 class="dice-total {{#if result.damage.isMinimum}}min-damage{{/if}}" data-tooltip="{{result.damage.formula}}">
+                                        {{result.damage.total}}
+                                    </h4>
+                                    {{{@root.dmgRoll.tooltip}}}
+                                </div>
+                            </div>
+
+                            {{!-- Apply damage button --}}
+                            <button class="apply-damage apply" data-target-id="{{result._id}}" data-action="damage"> 
+                                {{#if result.isHit}} <i class="fas fa-check"></i> {{else}} <i class="fas fa-times"></i> {{/if}}
+                            </button>
+                        </div>
+                    </div>
+
+
+                </div>
+            {{/each}}
+        </div>
+    {{/if}}
+
+    {{! On Use Effects}}
+    {{#if effects}}
+        {{~> "oh.on-use-effects"}}
+    {{/if}}
 </div>

--- a/static/templates/sheets/parts/unit-abilities.hbs
+++ b/static/templates/sheets/parts/unit-abilities.hbs
@@ -1,6 +1,7 @@
 <section class="items abilities flexcol">
     <header class="item-list-header flexrow">
         <div class="name">{{localize label}}</div>
+        <div class="item-action"></div>
         <div class="actions">{{localize "OH.Actions"}}</div>
         <div class="uses">{{localize "OH.Uses"}}</div>
         <div class="max">{{localize "OH.Max"}}</div>
@@ -18,6 +19,10 @@
                     <img class="icon" src="{{item.img}}" title="{{item.name}}"/>
                     <span>{{item.name}}</span>
                 </div>
+
+                <a class="item-action" data-tooltip="OH.ActionTypes.Use" data-action="itemUse">
+                    <i class="fas fa-bolt"></i>
+                </a>
 
                 <div class="actions">{{ifThen item.system.actionsToUse item.system.actionsToUse ""}}</div>
 

--- a/static/templates/sheets/parts/unit-items.hbs
+++ b/static/templates/sheets/parts/unit-items.hbs
@@ -1,6 +1,7 @@
 <section class="items equipment flexcol">
     <header class="item-list-header flexrow">
         <div class="name">{{localize label}}</div>
+        <div class="item-action"></div>
         <div class="actions">{{localize "OH.Actions"}}</div>
         <div class="uses">{{localize "OH.Uses"}}</div>
         <div class="max">{{localize "OH.Max"}}</div>
@@ -18,6 +19,10 @@
                     <img class="icon" src="{{item.img}}" title="{{item.name}}"/>
                     <span>{{item.name}}</span>
                 </div>
+
+                <a class="item-action" data-tooltip="OH.ActionTypes.Use" data-action="itemUse">
+                    <i class="fas fa-bolt"></i>
+                </a>
 
                 <div class="actions">{{ifThen item.system.actionsToUse item.system.actionsToUse ""}}</div>
 

--- a/static/templates/sheets/parts/unit-stats-defense.hbs
+++ b/static/templates/sheets/parts/unit-stats-defense.hbs
@@ -1,7 +1,7 @@
 <div class="flexcol">
     <table>
         <tr>
-            <th><button class="displayDefenses">Show</button></th>
+            <th><button type="button" class="displayDefenses">Show</button></th>
             <th>Total</th>
             <th>Base</th>
             <th>Stance</th>

--- a/static/templates/sheets/parts/unit-weapons.hbs
+++ b/static/templates/sheets/parts/unit-weapons.hbs
@@ -25,7 +25,7 @@
 
         {{!-- Use link for weapon attacks --}}
         <div class="use">
-          <a class="use-weapon" data-tooltip="OH.Attack">
+          <a class="item-action" data-tooltip="OH.Attack" data-action="attack">
             {{#if (eq item.system.weaponType "ranged")}}<i class="fas fa-gun"></i>{{/if}}
             {{#if (eq item.system.weaponType "melee")}}<i class="fas fa-sword"></i>{{/if}}
           </a>
@@ -45,7 +45,7 @@
         <div class="ammo flexrow">
           <div class="reload">
             {{#if item.document.canReload}}
-              <a data-tooltip="OH.Reload"><img class="icon" src="systems/outerheaven/icons/machine-gun-magazine.svg"></i></a>
+              <a class="item-action" data-tooltip="OH.Reload" data-action="reload"><img class="icon" src="systems/outerheaven/icons/machine-gun-magazine.svg"></i></a>
             {{/if}}
           </div>
           <input type="number" value={{item.document.system.capacity.value}} step="1" min="0" max="{{item.system.capacity.max}}" data-field="system.capacity.value" class="inline-edit"/>

--- a/static/templates/sheets/weapon-sheet.hbs
+++ b/static/templates/sheets/weapon-sheet.hbs
@@ -3,33 +3,47 @@
         <img src="{{item.img}}" data-edit="img" title="{{item.name}}" height="64" width="64"/>
         <h1><input name="name" type="text" value="{{item.name}}" placeholder="Name"/></h1>
     </header>
-    <div>
-        <div class="itemSection">
-            <select class="floatLeft" name="system.weaponType">
-                {{selectOptions config.weaponTypes selected=system.weaponType}}
-            </select>
-            <div class="floatRight">Power cost : <input class="smallInput" type="text" name="system.powerCost" value="{{system.powerCost}}" data-dtype="Number" /></div>
-            <br />
+
+    {{! Navigation }}
+    <nav class="sheet-tabs tabs" data-group="main" aria-role="Form Tab Navigation">
+        <a class="item" data-tab="details">{{localize "OH.Details"}}</a>
+        <a class="item" data-tab="effects">{{localize "OH.Effects"}}</a>
+    </nav>
+
+    <section class="content">
+        <div class="tab" data-tab="details">
+            <div class="itemSection">
+                <select class="floatLeft" name="system.weaponType">
+                    {{selectOptions config.weaponTypes selected=system.weaponType}}
+                </select>
+                <div class="floatRight">Power cost : <input class="smallInput" type="text" name="system.powerCost" value="{{system.powerCost}}" data-dtype="Number" /></div>
+                <br />
+            </div>
+            <div class="itemSection">
+                {{#if (eq system.weaponType "ranged")}}
+                {{> "oh.ranged-block"}}
+                {{/if}}
+                {{#if (eq system.weaponType "melee")}}
+                {{> "oh.melee-block"}}
+                {{/if}}
+            </div>
+            <div class="itemSection">
+                {{editor description target="system.description" button=true engine="prosemirror" owner=owner editable=editable}}
+            </div>
+            <div>
+                <p class="floatLeft">
+                    Tags : <input class="mediumInput" type="text" name="system.tags" value="{{system.tags}}" />
+                </p>
+                <p class="floatRight">
+                    Point cost : <input class="smallInput" type="text" name="system.pointCost" value="{{system.pointCost}}" data-dtype="Number" />
+                    Ignore cost : <input class="vCenter" type="checkbox" name="system.ignoreCost" {{checked system.ignoreCost}} />
+                </p>
+            </div>
         </div>
-        <div class="itemSection">
-            {{#if (eq system.weaponType "ranged")}}
-            {{> "oh.ranged-block"}}
-            {{/if}}
-            {{#if (eq system.weaponType "melee")}}
-            {{> "oh.melee-block"}}
-            {{/if}}
+
+        {{! Effects tab }}
+        <div class="tab" data-group="main" data-tab="effects">
+            {{>"oh.item-effects"}}
         </div>
-        <div class="itemSection">
-            {{editor description target="system.description" button=true engine="prosemirror" owner=owner editable=editable}}
-        </div>
-        <div>
-            <p class="floatLeft">
-                Tags : <input class="mediumInput" type="text" name="system.tags" value="{{system.tags}}" />
-            </p>
-            <p class="floatRight">
-                Point cost : <input class="smallInput" type="text" name="system.pointCost" value="{{system.pointCost}}" data-dtype="Number" />
-                Ignore cost : <input class="vCenter" type="checkbox" name="system.ignoreCost" {{checked system.ignoreCost}} />
-            </p>
-        </div>
-    </div>
+    </section>
 </form>


### PR DESCRIPTION
Adds features:
- Equipment and ability type items can be used, subtracting the appropriate resources.
- On-Use effects are attached to attack/use messages and can be applied to currently selected tokens.

Includes refactoring of:
- some styles in chat cards, making them a bit more generic so they can be reused.
- item usage is now triggered through `Item#use` and takes an `action` parameter to determine what kind of action is desired; creating wrapper functions is still possible, should e.g. module usage depend on that.
- a `SYSTEM` const is now used for a few more values, which sadly does introduce a bit of noise into the PR.